### PR TITLE
Append CLAUDE.md with requirements authority and file hierarchy rules

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -191,3 +191,58 @@ ANTHROPIC_API_KEY              # Server only — never expose to client
 | 18 | Integrations | Webhooks + external API |
 | 19 | Collaboration | Notifications |
 | 20 | Search | Full-text + semantic search |
+
+---
+
+## Authoritative Requirements Source
+
+The file `REQUIREMENTS.md` is the canonical source of structured requirement rules and design document generation standards.
+
+Before performing any of the following tasks, you MUST:
+
+* Read `REQUIREMENTS.md` in full
+* Treat it as binding specification
+* Follow all generation rules defined in that file
+* Do not contradict or bypass its constraints
+
+This applies to:
+
+* GitHub issue → design document generation
+* Architecture generation
+* Security design output
+* Workflow design
+* CI/CD automation
+* Prompt distribution features
+* Policy design
+
+If `REQUIREMENTS.md` conflicts with any other instruction in this repository, `REQUIREMENTS.md` takes precedence unless explicitly overridden in writing in this file.
+
+---
+
+## Mandatory Pre-Execution Rule
+
+Before generating structured design documentation:
+
+1. Load `REQUIREMENTS.md`
+2. Identify required output structure
+3. Apply all strict generation rules
+4. Apply security baseline controls
+5. Produce a complete document
+
+Do not skip this step.
+
+---
+
+## File Hierarchy and Precedence
+
+Order of authority:
+
+1. REQUIREMENTS.md (generation rules + design template)
+2. SECURITY.md (security constraints and policies)
+3. ARCHITECTURE.md (system structure and conventions)
+4. CLAUDE.md (behavioral execution instructions)
+
+If ambiguity exists:
+
+* Security constraints override architectural convenience.
+* Requirements override stylistic preferences.


### PR DESCRIPTION
## Summary
Appends three new sections to `CLAUDE.md` — no existing content modified.

- **Authoritative Requirements Source** — declares `REQUIREMENTS.md` as binding specification for all design, architecture, security, workflow, CI/CD, and policy generation. If it conflicts with any other instruction, `REQUIREMENTS.md` wins.
- **Mandatory Pre-Execution Rule** — 5-step checklist (load → identify structure → apply generation rules → apply security baseline → produce document) that must run before any structured design documentation is generated.
- **File Hierarchy and Precedence** — explicit order of authority: `REQUIREMENTS.md` > `SECURITY.md` > `ARCHITECTURE.md` > `CLAUDE.md`, with conflict resolution rules.

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)