### PR TITLE
[3] Core database schema

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,6 +32,15 @@ npm run format       # Format all files with Prettier
 npm run format:check # Check formatting without writing
 ```
 
+Supabase CLI (binary at `~/.local/bin/supabase`):
+```bash
+supabase login                                           # Authenticate (requires personal access token)
+supabase link --project-ref frvgorgoiunskjoptzcp        # Link to the Bricks Supabase project
+supabase db push                                         # Apply pending migrations
+supabase migration new <name>                            # Create a new migration file
+supabase gen types typescript --linked > types/database.ts  # Regenerate TypeScript types
+```
+
 To add a shadcn/ui component:
 ```bash
 NODE_EXTRA_CA_CERTS=/tmp/system-ca.pem npx shadcn@latest add <component>

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -1,0 +1,294 @@
+# Bricks — Database Schema
+
+> Applied via: `supabase/migrations/20260303000000_initial_schema.sql`
+
+## Extensions
+
+| Extension | Purpose |
+|---|---|
+| `pgcrypto` | `gen_random_uuid()` for primary keys |
+| `vector` | pgvector — semantic search and RAG (future issues #13, #14) |
+
+## Enums
+
+### `project_role`
+Role a user holds within a specific project.
+
+| Value | Description |
+|---|---|
+| `admin` | Full access; can invite members, manage settings, approve documents |
+| `architect` | Create, upload, edit documents; submit for review |
+| `civil_engineer` | Review, comment, approve, or request changes |
+| `carpenter` | Read-only access to approved documents |
+
+### `document_status`
+Lifecycle state of a document.
+
+| Value | Description |
+|---|---|
+| `draft` | Initial state; work in progress |
+| `in_review` | Submitted internally for review by civil engineers |
+| `approved` | Approved by a civil engineer or admin |
+| `changes_requested` | Reviewer requested changes |
+| `submitted` | Submitted to external authorities |
+
+### `document_content_type`
+How the content of a document version is stored.
+
+| Value | Description |
+|---|---|
+| `file` | Binary file stored in Supabase Storage; `storage_path` is set |
+| `rich_text` | Tiptap editor JSON stored in `rich_text_json` column |
+
+### `language_code`
+Supported application languages.
+
+| Value | Description |
+|---|---|
+| `no` | Norwegian Bokmål (default) |
+| `en` | English |
+
+---
+
+## Tables
+
+### `profiles`
+Extends `auth.users` with application-level user data. Created automatically by the `on_auth_user_created` trigger.
+
+| Column | Type | Nullable | Default | Description |
+|---|---|---|---|---|
+| `id` | `uuid` | NO | — | FK → `auth.users.id` (CASCADE delete) |
+| `full_name` | `text` | YES | — | User's display name |
+| `avatar_url` | `text` | YES | — | URL to profile image |
+| `language` | `language_code` | NO | `'no'` | Preferred UI language |
+| `created_at` | `timestamptz` | NO | `now()` | Row creation timestamp |
+| `updated_at` | `timestamptz` | NO | `now()` | Last update timestamp |
+
+**RLS policies:**
+- Owner can `SELECT` their own row
+- Owner can `UPDATE` their own row
+
+---
+
+### `organizations`
+Construction firms or architectural practices.
+
+| Column | Type | Nullable | Default | Description |
+|---|---|---|---|---|
+| `id` | `uuid` | NO | `gen_random_uuid()` | Primary key |
+| `name` | `text` | NO | — | Organization display name |
+| `slug` | `text` | NO | — | URL-safe unique identifier |
+| `logo_url` | `text` | YES | — | URL to organization logo |
+| `created_by` | `uuid` | NO | — | FK → `auth.users.id` |
+| `created_at` | `timestamptz` | NO | `now()` | Row creation timestamp |
+| `updated_at` | `timestamptz` | NO | `now()` | Last update timestamp |
+
+**RLS policies:**
+- Creator or any member of a project under this org can `SELECT`
+- Creator can `INSERT`
+- Creator can `UPDATE`
+
+---
+
+### `projects`
+Construction projects belonging to an organization.
+
+| Column | Type | Nullable | Default | Description |
+|---|---|---|---|---|
+| `id` | `uuid` | NO | `gen_random_uuid()` | Primary key |
+| `organization_id` | `uuid` | NO | — | FK → `organizations.id` (CASCADE delete) |
+| `name` | `text` | NO | — | Project name |
+| `description` | `text` | YES | — | Optional description |
+| `location` | `text` | YES | — | Physical location or address |
+| `status` | `text` | NO | `'active'` | `active` \| `archived` \| `completed` |
+| `created_by` | `uuid` | NO | — | FK → `auth.users.id` |
+| `created_at` | `timestamptz` | NO | `now()` | Row creation timestamp |
+| `updated_at` | `timestamptz` | NO | `now()` | Last update timestamp |
+
+**RLS policies:**
+- Project members can `SELECT`
+- Org creator can `INSERT`
+- Admin role members can `UPDATE`
+
+---
+
+### `project_members`
+Join table linking users to projects with a role. Enforces role-based access across the system.
+
+| Column | Type | Nullable | Default | Description |
+|---|---|---|---|---|
+| `id` | `uuid` | NO | `gen_random_uuid()` | Primary key |
+| `project_id` | `uuid` | NO | — | FK → `projects.id` (CASCADE delete) |
+| `user_id` | `uuid` | NO | — | FK → `auth.users.id` (CASCADE delete) |
+| `role` | `project_role` | NO | — | User's role in this project |
+| `invited_by` | `uuid` | YES | — | FK → `auth.users.id` (SET NULL on delete) |
+| `created_at` | `timestamptz` | NO | `now()` | Row creation timestamp |
+
+**Unique constraint:** `(project_id, user_id)`
+
+**RLS policies:**
+- Any member of the project can `SELECT` all members
+- Only `admin` role can `INSERT`, `UPDATE`, `DELETE` members
+
+---
+
+### `documents`
+Document metadata. The actual content lives in `document_versions`.
+
+| Column | Type | Nullable | Default | Description |
+|---|---|---|---|---|
+| `id` | `uuid` | NO | `gen_random_uuid()` | Primary key |
+| `project_id` | `uuid` | NO | — | FK → `projects.id` (CASCADE delete) |
+| `title` | `text` | NO | — | Document title |
+| `description` | `text` | YES | — | Optional description |
+| `status` | `document_status` | NO | `'draft'` | Current lifecycle status |
+| `current_version_id` | `uuid` | YES | — | FK → `document_versions.id` (SET NULL on delete) |
+| `created_by` | `uuid` | NO | — | FK → `auth.users.id` |
+| `created_at` | `timestamptz` | NO | `now()` | Row creation timestamp |
+| `updated_at` | `timestamptz` | NO | `now()` | Last update timestamp |
+
+**RLS policies:**
+- All project members can `SELECT`
+- `admin` and `architect` roles can `INSERT`
+- `admin` and `architect` roles can `UPDATE`
+- Only `admin` role can `DELETE`
+
+---
+
+### `document_versions`
+Immutable snapshots of document content. Once created, a version cannot be modified or deleted.
+
+| Column | Type | Nullable | Default | Description |
+|---|---|---|---|---|
+| `id` | `uuid` | NO | `gen_random_uuid()` | Primary key |
+| `document_id` | `uuid` | NO | — | FK → `documents.id` (CASCADE delete) |
+| `version_number` | `integer` | NO | — | Sequential version number (1, 2, 3…) |
+| `content_type` | `document_content_type` | NO | — | `file` or `rich_text` |
+| `storage_path` | `text` | YES | — | Supabase Storage object path (when `content_type = 'file'`) |
+| `rich_text_json` | `jsonb` | YES | — | Tiptap JSON content (when `content_type = 'rich_text'`) |
+| `file_name` | `text` | YES | — | Original filename |
+| `file_size` | `bigint` | YES | — | File size in bytes |
+| `mime_type` | `text` | YES | — | MIME type (e.g. `application/pdf`) |
+| `created_by` | `uuid` | NO | — | FK → `auth.users.id` |
+| `created_at` | `timestamptz` | NO | `now()` | Row creation timestamp |
+
+**Unique constraint:** `(document_id, version_number)`
+
+**Content constraint:** Exactly one of `storage_path` or `rich_text_json` must be set, matching `content_type`.
+
+**RLS policies:**
+- All project members can `SELECT`
+- `admin` and `architect` roles can `INSERT`
+- No `UPDATE` or `DELETE` allowed (versions are immutable)
+
+---
+
+### `document_status_history`
+Append-only audit log of every document status transition.
+
+| Column | Type | Nullable | Default | Description |
+|---|---|---|---|---|
+| `id` | `uuid` | NO | `gen_random_uuid()` | Primary key |
+| `document_id` | `uuid` | NO | — | FK → `documents.id` (CASCADE delete) |
+| `from_status` | `document_status` | YES | — | Previous status (`NULL` for first transition from draft) |
+| `to_status` | `document_status` | NO | — | New status |
+| `changed_by` | `uuid` | NO | — | FK → `auth.users.id` |
+| `note` | `text` | YES | — | Optional reviewer note |
+| `created_at` | `timestamptz` | NO | `now()` | Transition timestamp |
+
+**RLS policies:**
+- All project members can `SELECT`
+- Any project member can `INSERT` (transition enforced at application layer)
+- No `UPDATE` or `DELETE` allowed (immutable audit log)
+
+---
+
+### `comments`
+Threaded comments anchored to a specific document version.
+
+| Column | Type | Nullable | Default | Description |
+|---|---|---|---|---|
+| `id` | `uuid` | NO | `gen_random_uuid()` | Primary key |
+| `document_version_id` | `uuid` | NO | — | FK → `document_versions.id` (CASCADE delete) |
+| `parent_id` | `uuid` | YES | — | FK → `comments.id` for thread replies (CASCADE delete) |
+| `body` | `text` | NO | — | Comment content (plain text or Markdown) |
+| `created_by` | `uuid` | NO | — | FK → `auth.users.id` |
+| `created_at` | `timestamptz` | NO | `now()` | Row creation timestamp |
+| `updated_at` | `timestamptz` | NO | `now()` | Last edit timestamp |
+| `resolved_at` | `timestamptz` | YES | — | When the comment thread was resolved |
+| `resolved_by` | `uuid` | YES | — | FK → `auth.users.id` (SET NULL on delete) |
+
+**RLS policies:**
+- All project members can `SELECT`
+- Any project member can `INSERT`
+- Comment author can `UPDATE` their own comments
+- Comment author or project `admin` can `DELETE`
+
+---
+
+## Helper Functions
+
+### `is_project_member(p_project_id uuid) → boolean`
+Returns `true` if the currently authenticated user is a member of the given project. Used in RLS policies to avoid repeated subqueries.
+
+```sql
+select public.is_project_member('project-uuid-here');
+```
+
+### `get_user_project_role(p_project_id uuid) → project_role`
+Returns the authenticated user's `project_role` within the given project, or `NULL` if not a member. Used in RLS policies to check specific roles.
+
+```sql
+select public.get_user_project_role('project-uuid-here');
+```
+
+Both functions use `security definer` so they run as the table owner and can read `project_members` without triggering RLS on that table.
+
+---
+
+## Triggers
+
+### `on_auth_user_created`
+Fires `AFTER INSERT` on `auth.users`. Calls `public.handle_new_user()` which inserts a corresponding row in `public.profiles`, copying `full_name` and `avatar_url` from `raw_user_meta_data`.
+
+---
+
+## Relationships Diagram
+
+```
+auth.users (Supabase managed)
+  │
+  ├── profiles (1:1, auto-created via trigger)
+  │
+  └── organizations (created_by)
+        │
+        └── projects (organization_id)
+              │
+              ├── project_members (project_id) ──── auth.users (user_id)
+              │
+              └── documents (project_id)
+                    │
+                    ├── document_versions (document_id)
+                    │     │
+                    │     └── comments (document_version_id)
+                    │
+                    └── document_status_history (document_id)
+```
+
+---
+
+## Applying Migrations
+
+```bash
+# First-time setup (requires Supabase personal access token)
+supabase login
+supabase link --project-ref frvgorgoiunskjoptzcp
+
+# Push migrations to the linked Supabase project
+supabase db push
+
+# Regenerate TypeScript types after schema changes
+supabase gen types typescript --linked > types/database.ts
+```
+
+> **Note:** Never apply migrations by running SQL directly in the Supabase dashboard. All schema changes must go through migration files in `supabase/migrations/`.

--- a/supabase/.gitignore
+++ b/supabase/.gitignore
@@ -1,0 +1,8 @@
+# Supabase
+.branches
+.temp
+
+# dotenvx
+.env.keys
+.env.local
+.env.*.local

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -1,0 +1,308 @@
+# For detailed configuration reference documentation, visit:
+# https://supabase.com/docs/guides/local-development/cli/config
+# A string used to distinguish different Supabase projects on the same host. Defaults to the
+# working directory name when running `supabase init`.
+project_id = "Bricks"
+
+[api]
+enabled = true
+# Port to use for the API URL.
+port = 54321
+# Schemas to expose in your API. Tables, views and stored procedures in this schema will get API
+# endpoints. `public` and `graphql_public` schemas are included by default.
+schemas = ["public", "graphql_public"]
+# Extra schemas to add to the search_path of every request.
+extra_search_path = ["public", "extensions"]
+# The maximum number of rows returns from a view, table, or stored procedure. Limits payload size
+# for accidental or malicious requests.
+max_rows = 1000
+
+[api.tls]
+# Enable HTTPS endpoints locally using a self-signed certificate.
+enabled = false
+
+[db]
+# Port to use for the local database URL.
+port = 54322
+# Port used by db diff command to initialize the shadow database.
+shadow_port = 54320
+# The database major version to use. This has to be the same as your remote database's. Run `SHOW
+# server_version;` on the remote database to check.
+major_version = 15
+
+[db.pooler]
+enabled = false
+# Port to use for the local connection pooler.
+port = 54329
+# Specifies when a server connection can be reused by other clients.
+# Configure one of the supported pooler modes: `transaction`, `session`.
+pool_mode = "transaction"
+# How many server connections to allow per user/database pair.
+default_pool_size = 20
+# Maximum number of client connections allowed.
+max_client_conn = 100
+
+# [db.vault]
+# secret_key = "env(SECRET_VALUE)"
+
+[db.migrations]
+# Specifies an ordered list of schema files that describe your database.
+# Supports glob patterns relative to supabase directory: "./schemas/*.sql"
+schema_paths = []
+
+[db.seed]
+# If enabled, seeds the database after migrations during a db reset.
+enabled = true
+# Specifies an ordered list of seed files to load during db reset.
+# Supports glob patterns relative to supabase directory: "./seeds/*.sql"
+sql_paths = ["./seed.sql"]
+
+[realtime]
+enabled = true
+# Bind realtime via either IPv4 or IPv6. (default: IPv4)
+# ip_version = "IPv6"
+# The maximum length in bytes of HTTP request headers. (default: 4096)
+# max_header_length = 4096
+
+[studio]
+enabled = true
+# Port to use for Supabase Studio.
+port = 54323
+# External URL of the API server that frontend connects to.
+api_url = "http://127.0.0.1"
+# OpenAI API Key to use for Supabase AI in the Supabase Studio.
+openai_api_key = "env(OPENAI_API_KEY)"
+
+# Email testing server. Emails sent with the local dev setup are not actually sent - rather, they
+# are monitored, and you can view the emails that would have been sent from the web interface.
+[inbucket]
+enabled = true
+# Port to use for the email testing server web interface.
+port = 54324
+# Uncomment to expose additional ports for testing user applications that send emails.
+# smtp_port = 54325
+# pop3_port = 54326
+# admin_email = "admin@email.com"
+# sender_name = "Admin"
+
+[storage]
+enabled = true
+# The maximum file size allowed (e.g. "5MB", "500KB").
+file_size_limit = "50MiB"
+
+# Image transformation API is available to Supabase Pro plan.
+# [storage.image_transformation]
+# enabled = true
+
+# Uncomment to configure local storage buckets
+# [storage.buckets.images]
+# public = false
+# file_size_limit = "50MiB"
+# allowed_mime_types = ["image/png", "image/jpeg"]
+# objects_path = "./images"
+
+[auth]
+enabled = true
+# The base URL of your website. Used as an allow-list for redirects and for constructing URLs used
+# in emails.
+site_url = "http://127.0.0.1:3000"
+# A list of *exact* URLs that auth providers are permitted to redirect to post authentication.
+additional_redirect_urls = ["https://127.0.0.1:3000"]
+# How long tokens are valid for, in seconds. Defaults to 3600 (1 hour), maximum 604,800 (1 week).
+jwt_expiry = 3600
+# If disabled, the refresh token will never expire.
+enable_refresh_token_rotation = true
+# Allows refresh tokens to be reused after expiry, up to the specified interval in seconds.
+# Requires enable_refresh_token_rotation = true.
+refresh_token_reuse_interval = 10
+# Allow/disallow new user signups to your project.
+enable_signup = true
+# Allow/disallow anonymous sign-ins to your project.
+enable_anonymous_sign_ins = false
+# Allow/disallow testing manual linking of accounts
+enable_manual_linking = false
+# Passwords shorter than this value will be rejected as weak. Minimum 6, recommended 8 or more.
+minimum_password_length = 6
+# Passwords that do not meet the following requirements will be rejected as weak. Supported values
+# are: `letters_digits`, `lower_upper_letters_digits`, `lower_upper_letters_digits_symbols`
+password_requirements = ""
+
+[auth.rate_limit]
+# Number of emails that can be sent per hour. Requires auth.email.smtp to be enabled.
+email_sent = 2
+# Number of SMS messages that can be sent per hour. Requires auth.sms to be enabled.
+sms_sent = 30
+# Number of anonymous sign-ins that can be made per hour per IP address. Requires enable_anonymous_sign_ins = true.
+anonymous_users = 30
+# Number of sessions that can be refreshed in a 5 minute interval per IP address.
+token_refresh = 150
+# Number of sign up and sign-in requests that can be made in a 5 minute interval per IP address (excludes anonymous users).
+sign_in_sign_ups = 30
+# Number of OTP / Magic link verifications that can be made in a 5 minute interval per IP address.
+token_verifications = 30
+
+# Configure one of the supported captcha providers: `hcaptcha`, `turnstile`.
+# [auth.captcha]
+# enabled = true
+# provider = "hcaptcha"
+# secret = ""
+
+[auth.email]
+# Allow/disallow new user signups via email to your project.
+enable_signup = true
+# If enabled, a user will be required to confirm any email change on both the old, and new email
+# addresses. If disabled, only the new email is required to confirm.
+double_confirm_changes = true
+# If enabled, users need to confirm their email address before signing in.
+enable_confirmations = false
+# If enabled, users will need to reauthenticate or have logged in recently to change their password.
+secure_password_change = false
+# Controls the minimum amount of time that must pass before sending another signup confirmation or password reset email.
+max_frequency = "1s"
+# Number of characters used in the email OTP.
+otp_length = 6
+# Number of seconds before the email OTP expires (defaults to 1 hour).
+otp_expiry = 3600
+
+# Use a production-ready SMTP server
+# [auth.email.smtp]
+# enabled = true
+# host = "smtp.sendgrid.net"
+# port = 587
+# user = "apikey"
+# pass = "env(SENDGRID_API_KEY)"
+# admin_email = "admin@email.com"
+# sender_name = "Admin"
+
+# Uncomment to customize email template
+# [auth.email.template.invite]
+# subject = "You have been invited"
+# content_path = "./supabase/templates/invite.html"
+
+[auth.sms]
+# Allow/disallow new user signups via SMS to your project.
+enable_signup = false
+# If enabled, users need to confirm their phone number before signing in.
+enable_confirmations = false
+# Template for sending OTP to users
+template = "Your code is {{ .Code }}"
+# Controls the minimum amount of time that must pass before sending another sms otp.
+max_frequency = "5s"
+
+# Use pre-defined map of phone number to OTP for testing.
+# [auth.sms.test_otp]
+# 4152127777 = "123456"
+
+# Configure logged in session timeouts.
+# [auth.sessions]
+# Force log out after the specified duration.
+# timebox = "24h"
+# Force log out if the user has been inactive longer than the specified duration.
+# inactivity_timeout = "8h"
+
+# This hook runs before a token is issued and allows you to add additional claims based on the authentication method used.
+# [auth.hook.custom_access_token]
+# enabled = true
+# uri = "pg-functions://<database>/<schema>/<hook_name>"
+
+# Configure one of the supported SMS providers: `twilio`, `twilio_verify`, `messagebird`, `textlocal`, `vonage`.
+[auth.sms.twilio]
+enabled = false
+account_sid = ""
+message_service_sid = ""
+# DO NOT commit your Twilio auth token to git. Use environment variable substitution instead:
+auth_token = "env(SUPABASE_AUTH_SMS_TWILIO_AUTH_TOKEN)"
+
+# Multi-factor-authentication is available to Supabase Pro plan.
+[auth.mfa]
+# Control how many MFA factors can be enrolled at once per user.
+max_enrolled_factors = 10
+
+# Control MFA via App Authenticator (TOTP)
+[auth.mfa.totp]
+enroll_enabled = false
+verify_enabled = false
+
+# Configure MFA via Phone Messaging
+[auth.mfa.phone]
+enroll_enabled = false
+verify_enabled = false
+otp_length = 6
+template = "Your code is {{ .Code }}"
+max_frequency = "5s"
+
+# Configure MFA via WebAuthn
+# [auth.mfa.web_authn]
+# enroll_enabled = true
+# verify_enabled = true
+
+# Use an external OAuth provider. The full list of providers are: `apple`, `azure`, `bitbucket`,
+# `discord`, `facebook`, `github`, `gitlab`, `google`, `keycloak`, `linkedin_oidc`, `notion`, `twitch`,
+# `twitter`, `slack`, `spotify`, `workos`, `zoom`.
+[auth.external.apple]
+enabled = false
+client_id = ""
+# DO NOT commit your OAuth provider secret to git. Use environment variable substitution instead:
+secret = "env(SUPABASE_AUTH_EXTERNAL_APPLE_SECRET)"
+# Overrides the default auth redirectUrl.
+redirect_uri = ""
+# Overrides the default auth provider URL. Used to support self-hosted gitlab, single-tenant Azure,
+# or any other third-party OIDC providers.
+url = ""
+# If enabled, the nonce check will be skipped. Required for local sign in with Google auth.
+skip_nonce_check = false
+
+# Use Firebase Auth as a third-party provider alongside Supabase Auth.
+[auth.third_party.firebase]
+enabled = false
+# project_id = "my-firebase-project"
+
+# Use Auth0 as a third-party provider alongside Supabase Auth.
+[auth.third_party.auth0]
+enabled = false
+# tenant = "my-auth0-tenant"
+# tenant_region = "us"
+
+# Use AWS Cognito (Amplify) as a third-party provider alongside Supabase Auth.
+[auth.third_party.aws_cognito]
+enabled = false
+# user_pool_id = "my-user-pool-id"
+# user_pool_region = "us-east-1"
+
+# Use Clerk as a third-party provider alongside Supabase Auth.
+[auth.third_party.clerk]
+enabled = false
+# Obtain from https://clerk.com/setup/supabase
+# domain = "example.clerk.accounts.dev"
+
+[edge_runtime]
+enabled = true
+# Configure one of the supported request policies: `oneshot`, `per_worker`.
+# Use `oneshot` for hot reload, or `per_worker` for load testing.
+policy = "oneshot"
+# Port to attach the Chrome inspector for debugging edge functions.
+inspector_port = 8083
+# The Deno major version to use.
+deno_version = 1
+
+# [edge_runtime.secrets]
+# secret_key = "env(SECRET_VALUE)"
+
+[analytics]
+enabled = true
+port = 54327
+# Configure one of the supported backends: `postgres`, `bigquery`.
+backend = "postgres"
+
+# Experimental features may be deprecated any time
+[experimental]
+# Configures Postgres storage engine to use OrioleDB (S3)
+orioledb_version = ""
+# Configures S3 bucket URL, eg. <bucket_name>.s3-<region>.amazonaws.com
+s3_host = "env(S3_HOST)"
+# Configures S3 bucket region, eg. us-east-1
+s3_region = "env(S3_REGION)"
+# Configures AWS_ACCESS_KEY_ID for S3 bucket
+s3_access_key = "env(S3_ACCESS_KEY)"
+# Configures AWS_SECRET_ACCESS_KEY for S3 bucket
+s3_secret_key = "env(S3_SECRET_KEY)"

--- a/supabase/migrations/20260303000000_initial_schema.sql
+++ b/supabase/migrations/20260303000000_initial_schema.sql
@@ -1,0 +1,470 @@
+-- =============================================================================
+-- Bricks — Initial Schema
+-- Migration: 20260303000000_initial_schema
+-- =============================================================================
+-- Structure:
+--   1. Extensions
+--   2. Enums
+--   3. All table definitions (no policies yet)
+--   4. Deferred FK: documents.current_version_id → document_versions.id
+--   5. Helper functions
+--   6. Trigger: handle_new_user
+--   7. Enable RLS on all tables
+--   8. All RLS policies (after all tables exist)
+--   9. Indexes
+-- =============================================================================
+
+-- ---------------------------------------------------------------------------
+-- 1. Extensions
+-- ---------------------------------------------------------------------------
+create extension if not exists "pgcrypto";
+create extension if not exists "vector";
+
+-- ---------------------------------------------------------------------------
+-- 2. Enums
+-- ---------------------------------------------------------------------------
+create type public.project_role as enum (
+  'admin',
+  'architect',
+  'civil_engineer',
+  'carpenter'
+);
+
+create type public.document_status as enum (
+  'draft',
+  'in_review',
+  'approved',
+  'changes_requested',
+  'submitted'
+);
+
+create type public.document_content_type as enum (
+  'file',
+  'rich_text'
+);
+
+create type public.language_code as enum (
+  'no',
+  'en'
+);
+
+-- ---------------------------------------------------------------------------
+-- 3. Table definitions
+-- ---------------------------------------------------------------------------
+
+-- profiles ----------------------------------------------------------------
+create table public.profiles (
+  id          uuid        primary key references auth.users(id) on delete cascade,
+  full_name   text,
+  avatar_url  text,
+  language    public.language_code not null default 'no',
+  created_at  timestamptz not null default now(),
+  updated_at  timestamptz not null default now()
+);
+comment on table public.profiles is 'Extends auth.users with application-level user data.';
+
+-- organizations -----------------------------------------------------------
+create table public.organizations (
+  id          uuid        primary key default gen_random_uuid(),
+  name        text        not null,
+  slug        text        not null unique,
+  logo_url    text,
+  created_by  uuid        not null references auth.users(id) on delete restrict,
+  created_at  timestamptz not null default now(),
+  updated_at  timestamptz not null default now()
+);
+comment on table public.organizations is 'Construction firms or architectural practices using Bricks.';
+
+-- projects ----------------------------------------------------------------
+create table public.projects (
+  id              uuid        primary key default gen_random_uuid(),
+  organization_id uuid        not null references public.organizations(id) on delete cascade,
+  name            text        not null,
+  description     text,
+  location        text,
+  status          text        not null default 'active'
+                    check (status in ('active', 'archived', 'completed')),
+  created_by      uuid        not null references auth.users(id) on delete restrict,
+  created_at      timestamptz not null default now(),
+  updated_at      timestamptz not null default now()
+);
+comment on table public.projects is 'Construction projects belonging to an organization.';
+
+-- project_members ---------------------------------------------------------
+create table public.project_members (
+  id          uuid                primary key default gen_random_uuid(),
+  project_id  uuid                not null references public.projects(id) on delete cascade,
+  user_id     uuid                not null references auth.users(id) on delete cascade,
+  role        public.project_role not null,
+  invited_by  uuid                references auth.users(id) on delete set null,
+  created_at  timestamptz         not null default now(),
+  unique (project_id, user_id)
+);
+comment on table public.project_members is 'Membership and role of a user within a project.';
+
+-- documents ---------------------------------------------------------------
+create table public.documents (
+  id                  uuid                    primary key default gen_random_uuid(),
+  project_id          uuid                    not null references public.projects(id) on delete cascade,
+  title               text                    not null,
+  description         text,
+  status              public.document_status  not null default 'draft',
+  current_version_id  uuid,                   -- FK added after document_versions is created
+  created_by          uuid                    not null references auth.users(id) on delete restrict,
+  created_at          timestamptz             not null default now(),
+  updated_at          timestamptz             not null default now()
+);
+comment on table public.documents is 'Document metadata. Status tracks the lifecycle: draft → in_review → approved.';
+
+-- document_versions -------------------------------------------------------
+create table public.document_versions (
+  id             uuid                          primary key default gen_random_uuid(),
+  document_id    uuid                          not null references public.documents(id) on delete cascade,
+  version_number integer                       not null,
+  content_type   public.document_content_type  not null,
+  storage_path   text,
+  rich_text_json jsonb,
+  file_name      text,
+  file_size      bigint,
+  mime_type      text,
+  created_by     uuid                          not null references auth.users(id) on delete restrict,
+  created_at     timestamptz                   not null default now(),
+  unique (document_id, version_number),
+  constraint content_type_check check (
+    (content_type = 'file'      and storage_path is not null and rich_text_json is null)
+    or
+    (content_type = 'rich_text' and rich_text_json is not null and storage_path is null)
+  )
+);
+comment on table public.document_versions is 'Immutable version snapshot. Approved versions cannot be mutated.';
+
+-- document_status_history -------------------------------------------------
+create table public.document_status_history (
+  id            uuid                   primary key default gen_random_uuid(),
+  document_id   uuid                   not null references public.documents(id) on delete cascade,
+  from_status   public.document_status,
+  to_status     public.document_status not null,
+  changed_by    uuid                   not null references auth.users(id) on delete restrict,
+  note          text,
+  created_at    timestamptz            not null default now()
+);
+comment on table public.document_status_history is 'Append-only audit trail of document status transitions.';
+
+-- comments ----------------------------------------------------------------
+create table public.comments (
+  id                  uuid        primary key default gen_random_uuid(),
+  document_version_id uuid        not null references public.document_versions(id) on delete cascade,
+  parent_id           uuid        references public.comments(id) on delete cascade,
+  body                text        not null,
+  created_by          uuid        not null references auth.users(id) on delete restrict,
+  created_at          timestamptz not null default now(),
+  updated_at          timestamptz not null default now(),
+  resolved_at         timestamptz,
+  resolved_by         uuid        references auth.users(id) on delete set null
+);
+comment on table public.comments is 'Threaded comments on a specific document version.';
+
+-- ---------------------------------------------------------------------------
+-- 4. Deferred FK: documents.current_version_id → document_versions.id
+-- ---------------------------------------------------------------------------
+alter table public.documents
+  add constraint documents_current_version_id_fkey
+  foreign key (current_version_id)
+  references public.document_versions(id)
+  on delete set null
+  deferrable initially deferred;
+
+-- ---------------------------------------------------------------------------
+-- 5. Helper functions
+-- ---------------------------------------------------------------------------
+create or replace function public.is_project_member(p_project_id uuid)
+returns boolean
+language sql
+security definer
+stable
+as $$
+  select exists (
+    select 1 from public.project_members
+    where project_id = p_project_id
+      and user_id = auth.uid()
+  );
+$$;
+
+create or replace function public.get_user_project_role(p_project_id uuid)
+returns public.project_role
+language sql
+security definer
+stable
+as $$
+  select role from public.project_members
+  where project_id = p_project_id
+    and user_id = auth.uid()
+  limit 1;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- 6. Trigger: auto-create profiles row on new auth.users insert
+-- ---------------------------------------------------------------------------
+create or replace function public.handle_new_user()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  insert into public.profiles (id, full_name, avatar_url)
+  values (
+    new.id,
+    new.raw_user_meta_data ->> 'full_name',
+    new.raw_user_meta_data ->> 'avatar_url'
+  );
+  return new;
+end;
+$$;
+
+create trigger on_auth_user_created
+  after insert on auth.users
+  for each row execute function public.handle_new_user();
+
+-- ---------------------------------------------------------------------------
+-- 7. Enable RLS on all tables
+-- ---------------------------------------------------------------------------
+alter table public.profiles                enable row level security;
+alter table public.organizations           enable row level security;
+alter table public.projects                enable row level security;
+alter table public.project_members         enable row level security;
+alter table public.documents               enable row level security;
+alter table public.document_versions       enable row level security;
+alter table public.document_status_history enable row level security;
+alter table public.comments                enable row level security;
+
+-- ---------------------------------------------------------------------------
+-- 8. RLS policies
+-- ---------------------------------------------------------------------------
+
+-- profiles -----------------------------------------------------------------
+create policy "profiles: owner can select"
+  on public.profiles for select
+  using (auth.uid() = id);
+
+create policy "profiles: owner can update"
+  on public.profiles for update
+  using (auth.uid() = id)
+  with check (auth.uid() = id);
+
+-- organizations ------------------------------------------------------------
+create policy "organizations: members can select"
+  on public.organizations for select
+  using (
+    exists (
+      select 1
+      from public.projects p
+      join public.project_members pm on pm.project_id = p.id
+      where p.organization_id = organizations.id
+        and pm.user_id = auth.uid()
+    )
+    or created_by = auth.uid()
+  );
+
+create policy "organizations: creator can insert"
+  on public.organizations for insert
+  with check (created_by = auth.uid());
+
+create policy "organizations: creator can update"
+  on public.organizations for update
+  using (created_by = auth.uid())
+  with check (created_by = auth.uid());
+
+-- projects -----------------------------------------------------------------
+create policy "projects: members can select"
+  on public.projects for select
+  using (
+    exists (
+      select 1 from public.project_members pm
+      where pm.project_id = projects.id
+        and pm.user_id = auth.uid()
+    )
+  );
+
+create policy "projects: org creator can insert"
+  on public.projects for insert
+  with check (created_by = auth.uid());
+
+create policy "projects: admin can update"
+  on public.projects for update
+  using (
+    exists (
+      select 1 from public.project_members pm
+      where pm.project_id = projects.id
+        and pm.user_id = auth.uid()
+        and pm.role = 'admin'
+    )
+  );
+
+-- project_members ----------------------------------------------------------
+create policy "project_members: member can select"
+  on public.project_members for select
+  using (
+    exists (
+      select 1 from public.project_members pm
+      where pm.project_id = project_members.project_id
+        and pm.user_id = auth.uid()
+    )
+  );
+
+create policy "project_members: admin can insert"
+  on public.project_members for insert
+  with check (
+    exists (
+      select 1 from public.project_members pm
+      where pm.project_id = project_members.project_id
+        and pm.user_id = auth.uid()
+        and pm.role = 'admin'
+    )
+  );
+
+create policy "project_members: admin can update"
+  on public.project_members for update
+  using (
+    exists (
+      select 1 from public.project_members pm
+      where pm.project_id = project_members.project_id
+        and pm.user_id = auth.uid()
+        and pm.role = 'admin'
+    )
+  );
+
+create policy "project_members: admin can delete"
+  on public.project_members for delete
+  using (
+    exists (
+      select 1 from public.project_members pm
+      where pm.project_id = project_members.project_id
+        and pm.user_id = auth.uid()
+        and pm.role = 'admin'
+    )
+  );
+
+-- documents ----------------------------------------------------------------
+create policy "documents: project member can select"
+  on public.documents for select
+  using (public.is_project_member(project_id));
+
+create policy "documents: architect or admin can insert"
+  on public.documents for insert
+  with check (
+    public.get_user_project_role(project_id) in ('admin', 'architect')
+    and created_by = auth.uid()
+  );
+
+create policy "documents: architect or admin can update"
+  on public.documents for update
+  using (
+    public.get_user_project_role(project_id) in ('admin', 'architect')
+  );
+
+create policy "documents: admin can delete"
+  on public.documents for delete
+  using (
+    public.get_user_project_role(project_id) = 'admin'
+  );
+
+-- document_versions --------------------------------------------------------
+create policy "document_versions: project member can select"
+  on public.document_versions for select
+  using (
+    exists (
+      select 1 from public.documents d
+      where d.id = document_versions.document_id
+        and public.is_project_member(d.project_id)
+    )
+  );
+
+create policy "document_versions: architect or admin can insert"
+  on public.document_versions for insert
+  with check (
+    exists (
+      select 1 from public.documents d
+      where d.id = document_versions.document_id
+        and public.get_user_project_role(d.project_id) in ('admin', 'architect')
+    )
+    and created_by = auth.uid()
+  );
+
+-- document_status_history --------------------------------------------------
+create policy "document_status_history: project member can select"
+  on public.document_status_history for select
+  using (
+    exists (
+      select 1 from public.documents d
+      where d.id = document_status_history.document_id
+        and public.is_project_member(d.project_id)
+    )
+  );
+
+create policy "document_status_history: member can insert"
+  on public.document_status_history for insert
+  with check (
+    exists (
+      select 1 from public.documents d
+      where d.id = document_status_history.document_id
+        and public.is_project_member(d.project_id)
+    )
+    and changed_by = auth.uid()
+  );
+
+-- comments -----------------------------------------------------------------
+create policy "comments: project member can select"
+  on public.comments for select
+  using (
+    exists (
+      select 1
+      from public.document_versions dv
+      join public.documents d on d.id = dv.document_id
+      where dv.id = comments.document_version_id
+        and public.is_project_member(d.project_id)
+    )
+  );
+
+create policy "comments: project member can insert"
+  on public.comments for insert
+  with check (
+    exists (
+      select 1
+      from public.document_versions dv
+      join public.documents d on d.id = dv.document_id
+      where dv.id = comments.document_version_id
+        and public.is_project_member(d.project_id)
+    )
+    and created_by = auth.uid()
+  );
+
+create policy "comments: author can update"
+  on public.comments for update
+  using (created_by = auth.uid())
+  with check (created_by = auth.uid());
+
+create policy "comments: author or admin can delete"
+  on public.comments for delete
+  using (
+    created_by = auth.uid()
+    or exists (
+      select 1
+      from public.document_versions dv
+      join public.documents d on d.id = dv.document_id
+      where dv.id = comments.document_version_id
+        and public.get_user_project_role(d.project_id) = 'admin'
+    )
+  );
+
+-- ---------------------------------------------------------------------------
+-- 9. Indexes
+-- ---------------------------------------------------------------------------
+create index on public.project_members (user_id);
+create index on public.project_members (project_id);
+create index on public.documents (project_id);
+create index on public.documents (status);
+create index on public.document_versions (document_id);
+create index on public.document_status_history (document_id);
+create index on public.comments (document_version_id);
+create index on public.comments (parent_id);

--- a/types/database.ts
+++ b/types/database.ts
@@ -1,15 +1,531 @@
-/**
- * Supabase database type definitions.
- *
- * This file is a placeholder. After the schema is applied in issue #3,
- * regenerate with:
- *   npx supabase gen types typescript --local > types/database.ts
- */
+export type Json =
+  | string
+  | number
+  | boolean
+  | null
+  | { [key: string]: Json | undefined }
+  | Json[]
+
 export type Database = {
+  // Allows to automatically instantiate createClient with right options
+  // instead of createClient<Database, { PostgrestVersion: 'XX' }>(URL, KEY)
+  __InternalSupabase: {
+    PostgrestVersion: "14.1"
+  }
+  graphql_public: {
+    Tables: {
+      [_ in never]: never
+    }
+    Views: {
+      [_ in never]: never
+    }
+    Functions: {
+      graphql: {
+        Args: {
+          extensions?: Json
+          operationName?: string
+          query?: string
+          variables?: Json
+        }
+        Returns: Json
+      }
+    }
+    Enums: {
+      [_ in never]: never
+    }
+    CompositeTypes: {
+      [_ in never]: never
+    }
+  }
   public: {
-    Tables: Record<string, never>;
-    Views: Record<string, never>;
-    Functions: Record<string, never>;
-    Enums: Record<string, never>;
-  };
-};
+    Tables: {
+      comments: {
+        Row: {
+          body: string
+          created_at: string
+          created_by: string
+          document_version_id: string
+          id: string
+          parent_id: string | null
+          resolved_at: string | null
+          resolved_by: string | null
+          updated_at: string
+        }
+        Insert: {
+          body: string
+          created_at?: string
+          created_by: string
+          document_version_id: string
+          id?: string
+          parent_id?: string | null
+          resolved_at?: string | null
+          resolved_by?: string | null
+          updated_at?: string
+        }
+        Update: {
+          body?: string
+          created_at?: string
+          created_by?: string
+          document_version_id?: string
+          id?: string
+          parent_id?: string | null
+          resolved_at?: string | null
+          resolved_by?: string | null
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "comments_document_version_id_fkey"
+            columns: ["document_version_id"]
+            isOneToOne: false
+            referencedRelation: "document_versions"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "comments_parent_id_fkey"
+            columns: ["parent_id"]
+            isOneToOne: false
+            referencedRelation: "comments"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      document_status_history: {
+        Row: {
+          changed_by: string
+          created_at: string
+          document_id: string
+          from_status: Database["public"]["Enums"]["document_status"] | null
+          id: string
+          note: string | null
+          to_status: Database["public"]["Enums"]["document_status"]
+        }
+        Insert: {
+          changed_by: string
+          created_at?: string
+          document_id: string
+          from_status?: Database["public"]["Enums"]["document_status"] | null
+          id?: string
+          note?: string | null
+          to_status: Database["public"]["Enums"]["document_status"]
+        }
+        Update: {
+          changed_by?: string
+          created_at?: string
+          document_id?: string
+          from_status?: Database["public"]["Enums"]["document_status"] | null
+          id?: string
+          note?: string | null
+          to_status?: Database["public"]["Enums"]["document_status"]
+        }
+        Relationships: [
+          {
+            foreignKeyName: "document_status_history_document_id_fkey"
+            columns: ["document_id"]
+            isOneToOne: false
+            referencedRelation: "documents"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      document_versions: {
+        Row: {
+          content_type: Database["public"]["Enums"]["document_content_type"]
+          created_at: string
+          created_by: string
+          document_id: string
+          file_name: string | null
+          file_size: number | null
+          id: string
+          mime_type: string | null
+          rich_text_json: Json | null
+          storage_path: string | null
+          version_number: number
+        }
+        Insert: {
+          content_type: Database["public"]["Enums"]["document_content_type"]
+          created_at?: string
+          created_by: string
+          document_id: string
+          file_name?: string | null
+          file_size?: number | null
+          id?: string
+          mime_type?: string | null
+          rich_text_json?: Json | null
+          storage_path?: string | null
+          version_number: number
+        }
+        Update: {
+          content_type?: Database["public"]["Enums"]["document_content_type"]
+          created_at?: string
+          created_by?: string
+          document_id?: string
+          file_name?: string | null
+          file_size?: number | null
+          id?: string
+          mime_type?: string | null
+          rich_text_json?: Json | null
+          storage_path?: string | null
+          version_number?: number
+        }
+        Relationships: [
+          {
+            foreignKeyName: "document_versions_document_id_fkey"
+            columns: ["document_id"]
+            isOneToOne: false
+            referencedRelation: "documents"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      documents: {
+        Row: {
+          created_at: string
+          created_by: string
+          current_version_id: string | null
+          description: string | null
+          id: string
+          project_id: string
+          status: Database["public"]["Enums"]["document_status"]
+          title: string
+          updated_at: string
+        }
+        Insert: {
+          created_at?: string
+          created_by: string
+          current_version_id?: string | null
+          description?: string | null
+          id?: string
+          project_id: string
+          status?: Database["public"]["Enums"]["document_status"]
+          title: string
+          updated_at?: string
+        }
+        Update: {
+          created_at?: string
+          created_by?: string
+          current_version_id?: string | null
+          description?: string | null
+          id?: string
+          project_id?: string
+          status?: Database["public"]["Enums"]["document_status"]
+          title?: string
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "documents_current_version_id_fkey"
+            columns: ["current_version_id"]
+            isOneToOne: false
+            referencedRelation: "document_versions"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "documents_project_id_fkey"
+            columns: ["project_id"]
+            isOneToOne: false
+            referencedRelation: "projects"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      organizations: {
+        Row: {
+          created_at: string
+          created_by: string
+          id: string
+          logo_url: string | null
+          name: string
+          slug: string
+          updated_at: string
+        }
+        Insert: {
+          created_at?: string
+          created_by: string
+          id?: string
+          logo_url?: string | null
+          name: string
+          slug: string
+          updated_at?: string
+        }
+        Update: {
+          created_at?: string
+          created_by?: string
+          id?: string
+          logo_url?: string | null
+          name?: string
+          slug?: string
+          updated_at?: string
+        }
+        Relationships: []
+      }
+      profiles: {
+        Row: {
+          avatar_url: string | null
+          created_at: string
+          full_name: string | null
+          id: string
+          language: Database["public"]["Enums"]["language_code"]
+          updated_at: string
+        }
+        Insert: {
+          avatar_url?: string | null
+          created_at?: string
+          full_name?: string | null
+          id: string
+          language?: Database["public"]["Enums"]["language_code"]
+          updated_at?: string
+        }
+        Update: {
+          avatar_url?: string | null
+          created_at?: string
+          full_name?: string | null
+          id?: string
+          language?: Database["public"]["Enums"]["language_code"]
+          updated_at?: string
+        }
+        Relationships: []
+      }
+      project_members: {
+        Row: {
+          created_at: string
+          id: string
+          invited_by: string | null
+          project_id: string
+          role: Database["public"]["Enums"]["project_role"]
+          user_id: string
+        }
+        Insert: {
+          created_at?: string
+          id?: string
+          invited_by?: string | null
+          project_id: string
+          role: Database["public"]["Enums"]["project_role"]
+          user_id: string
+        }
+        Update: {
+          created_at?: string
+          id?: string
+          invited_by?: string | null
+          project_id?: string
+          role?: Database["public"]["Enums"]["project_role"]
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "project_members_project_id_fkey"
+            columns: ["project_id"]
+            isOneToOne: false
+            referencedRelation: "projects"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      projects: {
+        Row: {
+          created_at: string
+          created_by: string
+          description: string | null
+          id: string
+          location: string | null
+          name: string
+          organization_id: string
+          status: string
+          updated_at: string
+        }
+        Insert: {
+          created_at?: string
+          created_by: string
+          description?: string | null
+          id?: string
+          location?: string | null
+          name: string
+          organization_id: string
+          status?: string
+          updated_at?: string
+        }
+        Update: {
+          created_at?: string
+          created_by?: string
+          description?: string | null
+          id?: string
+          location?: string | null
+          name?: string
+          organization_id?: string
+          status?: string
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "projects_organization_id_fkey"
+            columns: ["organization_id"]
+            isOneToOne: false
+            referencedRelation: "organizations"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+    }
+    Views: {
+      [_ in never]: never
+    }
+    Functions: {
+      get_user_project_role: {
+        Args: { p_project_id: string }
+        Returns: Database["public"]["Enums"]["project_role"]
+      }
+      is_project_member: { Args: { p_project_id: string }; Returns: boolean }
+    }
+    Enums: {
+      document_content_type: "file" | "rich_text"
+      document_status:
+        | "draft"
+        | "in_review"
+        | "approved"
+        | "changes_requested"
+        | "submitted"
+      language_code: "no" | "en"
+      project_role: "admin" | "architect" | "civil_engineer" | "carpenter"
+    }
+    CompositeTypes: {
+      [_ in never]: never
+    }
+  }
+}
+
+type DatabaseWithoutInternals = Omit<Database, "__InternalSupabase">
+
+type DefaultSchema = DatabaseWithoutInternals[Extract<keyof Database, "public">]
+
+export type Tables<
+  DefaultSchemaTableNameOrOptions extends
+    | keyof (DefaultSchema["Tables"] & DefaultSchema["Views"])
+    | { schema: keyof DatabaseWithoutInternals },
+  TableName extends DefaultSchemaTableNameOrOptions extends {
+    schema: keyof DatabaseWithoutInternals
+  }
+    ? keyof (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"] &
+        DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Views"])
+    : never = never,
+> = DefaultSchemaTableNameOrOptions extends {
+  schema: keyof DatabaseWithoutInternals
+}
+  ? (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"] &
+      DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Views"])[TableName] extends {
+      Row: infer R
+    }
+    ? R
+    : never
+  : DefaultSchemaTableNameOrOptions extends keyof (DefaultSchema["Tables"] &
+        DefaultSchema["Views"])
+    ? (DefaultSchema["Tables"] &
+        DefaultSchema["Views"])[DefaultSchemaTableNameOrOptions] extends {
+        Row: infer R
+      }
+      ? R
+      : never
+    : never
+
+export type TablesInsert<
+  DefaultSchemaTableNameOrOptions extends
+    | keyof DefaultSchema["Tables"]
+    | { schema: keyof DatabaseWithoutInternals },
+  TableName extends DefaultSchemaTableNameOrOptions extends {
+    schema: keyof DatabaseWithoutInternals
+  }
+    ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"]
+    : never = never,
+> = DefaultSchemaTableNameOrOptions extends {
+  schema: keyof DatabaseWithoutInternals
+}
+  ? DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"][TableName] extends {
+      Insert: infer I
+    }
+    ? I
+    : never
+  : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema["Tables"]
+    ? DefaultSchema["Tables"][DefaultSchemaTableNameOrOptions] extends {
+        Insert: infer I
+      }
+      ? I
+      : never
+    : never
+
+export type TablesUpdate<
+  DefaultSchemaTableNameOrOptions extends
+    | keyof DefaultSchema["Tables"]
+    | { schema: keyof DatabaseWithoutInternals },
+  TableName extends DefaultSchemaTableNameOrOptions extends {
+    schema: keyof DatabaseWithoutInternals
+  }
+    ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"]
+    : never = never,
+> = DefaultSchemaTableNameOrOptions extends {
+  schema: keyof DatabaseWithoutInternals
+}
+  ? DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"][TableName] extends {
+      Update: infer U
+    }
+    ? U
+    : never
+  : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema["Tables"]
+    ? DefaultSchema["Tables"][DefaultSchemaTableNameOrOptions] extends {
+        Update: infer U
+      }
+      ? U
+      : never
+    : never
+
+export type Enums<
+  DefaultSchemaEnumNameOrOptions extends
+    | keyof DefaultSchema["Enums"]
+    | { schema: keyof DatabaseWithoutInternals },
+  EnumName extends DefaultSchemaEnumNameOrOptions extends {
+    schema: keyof DatabaseWithoutInternals
+  }
+    ? keyof DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions["schema"]]["Enums"]
+    : never = never,
+> = DefaultSchemaEnumNameOrOptions extends {
+  schema: keyof DatabaseWithoutInternals
+}
+  ? DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions["schema"]]["Enums"][EnumName]
+  : DefaultSchemaEnumNameOrOptions extends keyof DefaultSchema["Enums"]
+    ? DefaultSchema["Enums"][DefaultSchemaEnumNameOrOptions]
+    : never
+
+export type CompositeTypes<
+  PublicCompositeTypeNameOrOptions extends
+    | keyof DefaultSchema["CompositeTypes"]
+    | { schema: keyof DatabaseWithoutInternals },
+  CompositeTypeName extends PublicCompositeTypeNameOrOptions extends {
+    schema: keyof DatabaseWithoutInternals
+  }
+    ? keyof DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"]
+    : never = never,
+> = PublicCompositeTypeNameOrOptions extends {
+  schema: keyof DatabaseWithoutInternals
+}
+  ? DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"][CompositeTypeName]
+  : PublicCompositeTypeNameOrOptions extends keyof DefaultSchema["CompositeTypes"]
+    ? DefaultSchema["CompositeTypes"][PublicCompositeTypeNameOrOptions]
+    : never
+
+export const Constants = {
+  graphql_public: {
+    Enums: {},
+  },
+  public: {
+    Enums: {
+      document_content_type: ["file", "rich_text"],
+      document_status: [
+        "draft",
+        "in_review",
+        "approved",
+        "changes_requested",
+        "submitted",
+      ],
+      language_code: ["no", "en"],
+      project_role: ["admin", "architect", "civil_engineer", "carpenter"],
+    },
+  },
+} as const


### PR DESCRIPTION
## Summary

- Applies the complete initial Supabase schema via a single migration file (`20260303000000_initial_schema.sql`)
- 8 tables: `profiles`, `organizations`, `projects`, `project_members`, `documents`, `document_versions`, `document_status_history`, `comments`
- RLS enabled on every table with policies enforcing the 4-role model (`admin`, `architect`, `civil_engineer`, `carpenter`)
- Auto-profile trigger, helper functions (`is_project_member`, `get_user_project_role`), pgvector extension
- `/docs/schema.md` documents every table, column, and relationship
- `types/database.ts` regenerated from live schema

## Test plan

- [ ] Verify all 8 tables appear in Supabase dashboard → Table Editor
- [ ] Verify RLS is enabled on all tables
- [ ] Verify `on_auth_user_created` trigger exists under Database → Triggers
- [ ] Verify `is_project_member` and `get_user_project_role` functions exist
- [ ] Typecheck passes: `npm run typecheck`
- [ ] Lint passes: `npm run lint`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)