### PR TITLE
[32] Add Semgrep static analysis to PR checks

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -1,0 +1,42 @@
+name: Semgrep
+
+on:
+  pull_request: {}
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+  security-events: write  # required to upload SARIF to GitHub Code Scanning
+
+jobs:
+  semgrep:
+    name: Static analysis
+    runs-on: ubuntu-latest
+    container:
+      image: semgrep/semgrep
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run Semgrep
+        run: >
+          semgrep scan
+          --config p/default
+          --config p/typescript
+          --config p/react
+          --config p/nextjs
+          --config p/secrets
+          --error
+          --sarif
+          --output semgrep.sarif
+        env:
+          # Optional: set SEMGREP_APP_TOKEN in repo secrets for dashboard results
+          # at https://semgrep.dev. Leave unset to run fully headless.
+          SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}
+
+      - name: Upload SARIF to GitHub Code Scanning
+        if: always()  # upload even when semgrep exits non-zero
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: semgrep.sarif


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/semgrep.yml` that runs on every `pull_request` and push to `main`
- Uses the official `semgrep/semgrep` container (no install step, always up to date)
- Scans rulesets: `p/default`, `p/typescript`, `p/react`, `p/nextjs`, `p/secrets`
- Exits non-zero (blocks PR) on any `ERROR` severity finding
- Uploads SARIF results to GitHub Code Scanning — findings appear inline on the PR diff
- `SEMGREP_APP_TOKEN` secret is optional; workflow runs fully headless without it

## Test plan

- [ ] Confirm the `Semgrep / Static analysis` check appears on this PR
- [ ] Verify SARIF results appear under Security → Code Scanning after merge
- [ ] Add a `# nosemgrep` comment to suppress a false positive and confirm it is ignored

🤖 Generated with [Claude Code](https://claude.ai/claude-code)