### PR TITLE
[34] Add Trivy SCA scan and Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,31 @@
+version: 2
+updates:
+  # npm dependencies
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+      timezone: Europe/Oslo
+    open-pull-requests-limit: 10
+    groups:
+      # Batch non-breaking minor and patch updates into a single PR
+      minor-and-patch:
+        update-types:
+          - minor
+          - patch
+    labels:
+      - dependencies
+
+  # GitHub Actions
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+      timezone: Europe/Oslo
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies

--- a/.github/workflows/sca.yml
+++ b/.github/workflows/sca.yml
@@ -1,0 +1,36 @@
+name: SCA
+
+on:
+  pull_request: {}
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+  security-events: write  # required to upload SARIF to GitHub Code Scanning
+
+jobs:
+  trivy:
+    name: Dependency vulnerability scan
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run Trivy (filesystem scan)
+        uses: aquasecurity/trivy-action@master
+        with:
+          scan-type: fs
+          scan-ref: .
+          scanners: vuln,secret,misconfig
+          severity: HIGH,CRITICAL
+          exit-code: "1"          # block PR on HIGH or CRITICAL findings
+          format: sarif
+          output: trivy.sarif
+          ignore-unfixed: true    # suppress CVEs with no available fix
+
+      - name: Upload SARIF to GitHub Code Scanning
+        if: always()              # upload even when trivy exits non-zero
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: trivy.sarif


### PR DESCRIPTION
## Summary

- **Trivy** (`sca.yml`): filesystem scan on every PR and push to `main`; blocks on `HIGH`/`CRITICAL` CVEs; suppresses unfixed findings to reduce noise; uploads SARIF to GitHub Code Scanning for inline annotations
- **Dependabot** (`dependabot.yml`): weekly npm + GitHub Actions updates, Monday 06:00 Oslo time; minor/patch grouped into single PRs to reduce review noise
- Dependabot vulnerability alerts and automated security fixes enabled via GitHub API

## Test plan

- [ ] Confirm `SCA / Dependency vulnerability scan` check appears on this PR
- [ ] Verify SARIF results appear under Security → Code Scanning after merge
- [ ] Verify Dependabot is active under Insights → Dependency graph → Dependabot
- [ ] Confirm a future dependency-update PR carries the `dependencies` label

🤖 Generated with [Claude Code](https://claude.ai/claude-code)