### PR TITLE
[4] Authentication — sign-up, sign-in, sign-out

### DIFF
--- a/app/(auth)/layout.tsx
+++ b/app/(auth)/layout.tsx
@@ -1,0 +1,21 @@
+import Link from "next/link";
+import { Logo } from "@/components/logo";
+
+export default function AuthLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="min-h-screen flex flex-col items-center justify-center bg-[var(--background)] px-4">
+      <div className="w-full max-w-sm space-y-8">
+        <div className="flex justify-center">
+          <Link href="/" aria-label="Back to homepage">
+            <Logo size="md" showWordmark />
+          </Link>
+        </div>
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/app/(auth)/sign-in/page.tsx
+++ b/app/(auth)/sign-in/page.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import { useActionState } from "react";
+import Link from "next/link";
+import { signIn, type AuthState } from "@/lib/actions/auth";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+
+const initialState: AuthState = {};
+
+export default function SignInPage() {
+  const [state, formAction, pending] = useActionState(signIn, initialState);
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Sign in</CardTitle>
+        <CardDescription>
+          Enter your email and password to access your projects.
+        </CardDescription>
+      </CardHeader>
+
+      <form action={formAction}>
+        <CardContent className="space-y-4">
+          {state.error && (
+            <p role="alert" className="text-sm text-destructive">
+              {state.error}
+            </p>
+          )}
+
+          <div className="space-y-2">
+            <Label htmlFor="email">Email</Label>
+            <Input
+              id="email"
+              name="email"
+              type="email"
+              autoComplete="email"
+              required
+              placeholder="you@example.com"
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="password">Password</Label>
+            <Input
+              id="password"
+              name="password"
+              type="password"
+              autoComplete="current-password"
+              required
+              placeholder="••••••••"
+            />
+          </div>
+        </CardContent>
+
+        <CardFooter className="flex flex-col gap-4">
+          <Button type="submit" className="w-full" disabled={pending}>
+            {pending ? "Signing in…" : "Sign in"}
+          </Button>
+
+          <p className="text-sm text-muted-foreground text-center">
+            Don&apos;t have an account?{" "}
+            <Link
+              href="/sign-up"
+              className="text-foreground underline underline-offset-4 hover:text-primary"
+            >
+              Sign up
+            </Link>
+          </p>
+        </CardFooter>
+      </form>
+    </Card>
+  );
+}

--- a/app/(auth)/sign-up/page.tsx
+++ b/app/(auth)/sign-up/page.tsx
@@ -1,0 +1,114 @@
+"use client";
+
+import { useActionState } from "react";
+import Link from "next/link";
+import { signUp, type AuthState } from "@/lib/actions/auth";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+
+const initialState: AuthState = {};
+
+export default function SignUpPage() {
+  const [state, formAction, pending] = useActionState(signUp, initialState);
+
+  if (state.message) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>Check your email</CardTitle>
+          <CardDescription>{state.message}</CardDescription>
+        </CardHeader>
+        <CardFooter>
+          <Link href="/sign-in" className="w-full">
+            <Button variant="outline" className="w-full">
+              Back to sign in
+            </Button>
+          </Link>
+        </CardFooter>
+      </Card>
+    );
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Create an account</CardTitle>
+        <CardDescription>
+          Join Bricks to manage your construction documentation.
+        </CardDescription>
+      </CardHeader>
+
+      <form action={formAction}>
+        <CardContent className="space-y-4">
+          {state.error && (
+            <p role="alert" className="text-sm text-destructive">
+              {state.error}
+            </p>
+          )}
+
+          <div className="space-y-2">
+            <Label htmlFor="full_name">Full name</Label>
+            <Input
+              id="full_name"
+              name="full_name"
+              type="text"
+              autoComplete="name"
+              required
+              placeholder="Ola Nordmann"
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="email">Email</Label>
+            <Input
+              id="email"
+              name="email"
+              type="email"
+              autoComplete="email"
+              required
+              placeholder="you@example.com"
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="password">Password</Label>
+            <Input
+              id="password"
+              name="password"
+              type="password"
+              autoComplete="new-password"
+              required
+              minLength={6}
+              placeholder="••••••••"
+            />
+          </div>
+        </CardContent>
+
+        <CardFooter className="flex flex-col gap-4">
+          <Button type="submit" className="w-full" disabled={pending}>
+            {pending ? "Creating account…" : "Create account"}
+          </Button>
+
+          <p className="text-sm text-muted-foreground text-center">
+            Already have an account?{" "}
+            <Link
+              href="/sign-in"
+              className="text-foreground underline underline-offset-4 hover:text-primary"
+            >
+              Sign in
+            </Link>
+          </p>
+        </CardFooter>
+      </form>
+    </Card>
+  );
+}

--- a/app/app/page.tsx
+++ b/app/app/page.tsx
@@ -1,0 +1,44 @@
+import { redirect } from "next/navigation";
+import { createClient } from "@/lib/supabase/server";
+import { signOut } from "@/lib/actions/auth";
+import { Button } from "@/components/ui/button";
+import { Logo } from "@/components/logo";
+
+export default async function AppPage() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) redirect("/sign-in");
+
+  const { data: profile } = await supabase
+    .from("profiles")
+    .select("full_name")
+    .eq("id", user.id)
+    .single();
+
+  return (
+    <div className="min-h-screen bg-[var(--background)]">
+      <header className="border-b border-border/40 bg-background/95 backdrop-blur">
+        <div className="max-w-7xl mx-auto px-6 h-14 flex items-center justify-between">
+          <Logo size="sm" showWordmark />
+          <form action={signOut}>
+            <Button variant="ghost" size="sm" type="submit">
+              Sign out
+            </Button>
+          </form>
+        </div>
+      </header>
+
+      <main className="max-w-7xl mx-auto px-6 py-12">
+        <h1 className="text-2xl font-semibold text-foreground">
+          Welcome{profile?.full_name ? `, ${profile.full_name}` : " back"}.
+        </h1>
+        <p className="mt-2 text-muted-foreground">
+          Projects and documents will appear here in issue #6.
+        </p>
+      </main>
+    </div>
+  );
+}

--- a/components/ui/card.tsx
+++ b/components/ui/card.tsx
@@ -1,0 +1,92 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+function Card({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card"
+      className={cn(
+        "flex flex-col gap-6 rounded-xl border bg-card py-6 text-card-foreground shadow-sm",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CardHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-header"
+      className={cn(
+        "@container/card-header grid auto-rows-min grid-rows-[auto_auto] items-start gap-2 px-6 has-data-[slot=card-action]:grid-cols-[1fr_auto] [.border-b]:pb-6",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CardTitle({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-title"
+      className={cn("leading-none font-semibold", className)}
+      {...props}
+    />
+  )
+}
+
+function CardDescription({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-description"
+      className={cn("text-sm text-muted-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+function CardAction({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-action"
+      className={cn(
+        "col-start-2 row-span-2 row-start-1 self-start justify-self-end",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CardContent({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-content"
+      className={cn("px-6", className)}
+      {...props}
+    />
+  )
+}
+
+function CardFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-footer"
+      className={cn("flex items-center px-6 [.border-t]:pt-6", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Card,
+  CardHeader,
+  CardFooter,
+  CardTitle,
+  CardAction,
+  CardDescription,
+  CardContent,
+}

--- a/components/ui/input.tsx
+++ b/components/ui/input.tsx
@@ -1,0 +1,21 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+function Input({ className, type, ...props }: React.ComponentProps<"input">) {
+  return (
+    <input
+      type={type}
+      data-slot="input"
+      className={cn(
+        "h-9 w-full min-w-0 rounded-md border border-input bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none selection:bg-primary selection:text-primary-foreground file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm dark:bg-input/30",
+        "focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50",
+        "aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Input }

--- a/components/ui/label.tsx
+++ b/components/ui/label.tsx
@@ -1,0 +1,24 @@
+"use client"
+
+import * as React from "react"
+import { Label as LabelPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function Label({
+  className,
+  ...props
+}: React.ComponentProps<typeof LabelPrimitive.Root>) {
+  return (
+    <LabelPrimitive.Root
+      data-slot="label"
+      className={cn(
+        "flex items-center gap-2 text-sm leading-none font-medium select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Label }

--- a/lib/actions/auth.ts
+++ b/lib/actions/auth.ts
@@ -1,0 +1,75 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { redirect } from "next/navigation";
+import { createClient } from "@/lib/supabase/server";
+
+export type AuthState = {
+  error?: string;
+  message?: string;
+};
+
+export async function signUp(
+  _prevState: AuthState,
+  formData: FormData,
+): Promise<AuthState> {
+  const supabase = await createClient();
+
+  const email = formData.get("email") as string;
+  const password = formData.get("password") as string;
+  const fullName = formData.get("full_name") as string;
+
+  const { error } = await supabase.auth.signUp({
+    email,
+    password,
+    options: {
+      data: { full_name: fullName },
+    },
+  });
+
+  if (error) {
+    // Never return raw Supabase error messages to the client
+    if (error.message.toLowerCase().includes("already registered")) {
+      return { error: "An account with this email already exists." };
+    }
+    if (error.message.toLowerCase().includes("password")) {
+      return { error: "Password must be at least 6 characters." };
+    }
+    return { error: "Could not create account. Please try again." };
+  }
+
+  return {
+    message:
+      "Check your email for a verification link before signing in.",
+  };
+}
+
+export async function signIn(
+  _prevState: AuthState,
+  formData: FormData,
+): Promise<AuthState> {
+  const supabase = await createClient();
+
+  const email = formData.get("email") as string;
+  const password = formData.get("password") as string;
+
+  const { error } = await supabase.auth.signInWithPassword({
+    email,
+    password,
+  });
+
+  if (error) {
+    // Generic message — do not reveal whether the email or password is wrong
+    return { error: "Incorrect email or password." };
+  }
+
+  revalidatePath("/", "layout");
+  redirect("/app");
+}
+
+export async function signOut(): Promise<void> {
+  const supabase = await createClient();
+  await supabase.auth.signOut();
+  revalidatePath("/", "layout");
+  redirect("/sign-in");
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -29,13 +29,23 @@ export async function middleware(request: NextRequest) {
     data: { user },
   } = await supabase.auth.getUser();
 
+  const { pathname } = request.nextUrl;
+
   // Redirect unauthenticated users away from protected routes.
-  // Protected routes will be added under /app/* in issue #4.
-  const isProtectedRoute = request.nextUrl.pathname.startsWith("/app");
+  const isProtectedRoute = pathname.startsWith("/app");
   if (isProtectedRoute && !user) {
-    const signInUrl = request.nextUrl.clone();
-    signInUrl.pathname = "/sign-in";
-    return NextResponse.redirect(signInUrl);
+    const url = request.nextUrl.clone();
+    url.pathname = "/sign-in";
+    return NextResponse.redirect(url);
+  }
+
+  // Redirect authenticated users away from auth pages.
+  const isAuthRoute =
+    pathname.startsWith("/sign-in") || pathname.startsWith("/sign-up");
+  if (isAuthRoute && user) {
+    const url = request.nextUrl.clone();
+    url.pathname = "/app";
+    return NextResponse.redirect(url);
   }
 
   return supabaseResponse;


### PR DESCRIPTION
## Summary

- **Server actions** (`lib/actions/auth.ts`): `signUp`, `signIn`, `signOut` — no raw Supabase errors exposed to the client; generic messages only
- **Sign-up page** (`/sign-up`): full name + email + password; shows email verification prompt on success
- **Sign-in page** (`/sign-in`): email + password; redirects to `/app` on success
- **Auth layout**: centred card shell with Bricks logo linking back to homepage
- **Protected page** (`/app`): minimal shell showing user's name from `profiles` + sign-out button
- **Middleware**: updated to also redirect authenticated users away from `/sign-in` and `/sign-up`
- Sessions in HTTP-only cookies via `@supabase/ssr` — never localStorage
- `profiles` row auto-created by `on_auth_user_created` trigger (from issue #3)

## Test plan

- [ ] Sign up with a new email → receives verification email → cannot access `/app` before verifying
- [ ] After email verification, sign in → redirected to `/app` → profile name shows
- [ ] Sign out → session invalidated → redirected to `/sign-in`
- [ ] Unauthenticated visit to `/app` → redirected to `/sign-in`
- [ ] Authenticated visit to `/sign-in` → redirected to `/app`
- [ ] Wrong password → shows "Incorrect email or password." (no field-specific hint)
- [ ] Check browser DevTools: session cookie is `HttpOnly`, not in `localStorage`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)