### PR TITLE
[5] Role-based access control

### DIFF
--- a/hooks/useRole.ts
+++ b/hooks/useRole.ts
@@ -1,0 +1,80 @@
+"use client";
+
+/**
+ * useRole — returns the current user's role within a project.
+ *
+ * ⚠️  UI-ONLY: This hook is for showing/hiding UI elements only.
+ *     It is NOT authoritative for access control.
+ *     All permission enforcement happens server-side via RLS and
+ *     requireProjectRole() in API routes and server actions.
+ */
+
+import { useEffect, useState } from "react";
+import { createClient } from "@/lib/supabase/client";
+import type { ProjectRole } from "@/lib/auth/rbac";
+
+type RoleState = {
+  role: ProjectRole | null;
+  loading: boolean;
+  error: string | null;
+};
+
+export function useRole(projectId: string | null): RoleState {
+  const [state, setState] = useState<RoleState>({
+    role: null,
+    loading: true,
+    error: null,
+  });
+
+  useEffect(() => {
+    if (!projectId) return;
+
+    let cancelled = false;
+    const supabase = createClient();
+
+    supabase
+      .rpc("get_user_project_role", { p_project_id: projectId })
+      .then(({ data, error }) => {
+        if (cancelled) return;
+        if (error) {
+          setState({ role: null, loading: false, error: error.message });
+        } else {
+          setState({
+            role: (data as ProjectRole) ?? null,
+            loading: false,
+            error: null,
+          });
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [projectId]);
+
+  return state;
+}
+
+// ---------------------------------------------------------------------------
+// Derived convenience hooks (built on top of useRole — also UI-only)
+// ---------------------------------------------------------------------------
+
+export function useCanWriteDocuments(projectId: string | null): boolean {
+  const { role } = useRole(projectId);
+  return role === "admin" || role === "architect";
+}
+
+export function useCanReviewDocuments(projectId: string | null): boolean {
+  const { role } = useRole(projectId);
+  return role === "admin" || role === "civil_engineer";
+}
+
+export function useCanManageMembers(projectId: string | null): boolean {
+  const { role } = useRole(projectId);
+  return role === "admin";
+}
+
+export function useIsAdmin(projectId: string | null): boolean {
+  const { role } = useRole(projectId);
+  return role === "admin";
+}

--- a/lib/auth/rbac.ts
+++ b/lib/auth/rbac.ts
@@ -1,0 +1,123 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { Database } from "@/types/database";
+
+export type ProjectRole = Database["public"]["Enums"]["project_role"];
+export type DocumentStatus = Database["public"]["Enums"]["document_status"];
+
+// ---------------------------------------------------------------------------
+// Role resolution
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns the calling user's role within a project, or null if they are not
+ * a member. Uses the `get_user_project_role` DB function so the lookup is
+ * a single indexed query scoped to the authenticated user.
+ */
+export async function getUserProjectRole(
+  supabase: SupabaseClient<Database>,
+  projectId: string,
+): Promise<ProjectRole | null> {
+  const { data, error } = await supabase.rpc("get_user_project_role", {
+    p_project_id: projectId,
+  });
+  if (error || !data) return null;
+  return data as ProjectRole;
+}
+
+// ---------------------------------------------------------------------------
+// Route-level guard (use inside Server Components and Route Handlers)
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolves the calling user's role and throws a `Response` with status 403
+ * if the role is not in `allowedRoles`. Returns the resolved role if allowed.
+ *
+ * Usage in a Route Handler:
+ *   const role = await requireProjectRole(supabase, projectId, "admin", "architect");
+ */
+export async function requireProjectRole(
+  supabase: SupabaseClient<Database>,
+  projectId: string,
+  ...allowedRoles: ProjectRole[]
+): Promise<ProjectRole> {
+  const role = await getUserProjectRole(supabase, projectId);
+
+  if (!role || !allowedRoles.includes(role)) {
+    throw new Response(
+      JSON.stringify({ error: "Insufficient permissions for this action." }),
+      { status: 403, headers: { "Content-Type": "application/json" } },
+    );
+  }
+
+  return role;
+}
+
+// ---------------------------------------------------------------------------
+// Status transition rules
+// ---------------------------------------------------------------------------
+
+/**
+ * Defines which roles can make which document status transitions.
+ *
+ * Transition table:
+ *   architect      : draft → in_review
+ *                    changes_requested → in_review
+ *                    approved → submitted
+ *   civil_engineer : in_review → approved
+ *                    in_review → changes_requested
+ *   admin          : any → any
+ *   carpenter      : no transitions permitted
+ */
+const ALLOWED_TRANSITIONS: Record<
+  ProjectRole,
+  Array<{ from: DocumentStatus; to: DocumentStatus }>
+> = {
+  admin: [
+    { from: "draft", to: "in_review" },
+    { from: "in_review", to: "approved" },
+    { from: "in_review", to: "changes_requested" },
+    { from: "changes_requested", to: "in_review" },
+    { from: "approved", to: "submitted" },
+    { from: "draft", to: "approved" }, // admin override
+  ],
+  architect: [
+    { from: "draft", to: "in_review" },
+    { from: "changes_requested", to: "in_review" },
+    { from: "approved", to: "submitted" },
+  ],
+  civil_engineer: [
+    { from: "in_review", to: "approved" },
+    { from: "in_review", to: "changes_requested" },
+  ],
+  carpenter: [],
+};
+
+/**
+ * Returns true if `role` is permitted to transition a document from
+ * `fromStatus` to `toStatus`. Pure function — no DB access.
+ */
+export function canTransitionDocumentStatus(
+  role: ProjectRole,
+  fromStatus: DocumentStatus,
+  toStatus: DocumentStatus,
+): boolean {
+  return ALLOWED_TRANSITIONS[role].some(
+    (t) => t.from === fromStatus && t.to === toStatus,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Convenience predicates (use in server actions / route handlers)
+// ---------------------------------------------------------------------------
+
+export const ROLES_THAT_CAN_WRITE_DOCUMENTS: ProjectRole[] = [
+  "admin",
+  "architect",
+];
+
+export const ROLES_THAT_CAN_REVIEW_DOCUMENTS: ProjectRole[] = [
+  "admin",
+  "civil_engineer",
+];
+
+export const ROLES_THAT_CAN_MANAGE_MEMBERS: ProjectRole[] = ["admin"];

--- a/supabase/migrations/20260303150614_rbac_policies.sql
+++ b/supabase/migrations/20260303150614_rbac_policies.sql
@@ -1,0 +1,47 @@
+-- =============================================================================
+-- Bricks — RBAC policy refinements
+-- Migration: 20260303150614_rbac_policies
+-- =============================================================================
+-- Changes from initial schema:
+--
+-- 1. document_versions SELECT: carpenters restricted to versions whose
+--    parent document status is 'approved' (all other roles see all versions)
+--
+-- 2. documents UPDATE: civil_engineer added as an actor who can update
+--    a document row (for status transitions to 'approved' / 'changes_requested').
+--    Field-level restrictions (which columns/values) are enforced in server
+--    actions — RLS governs row access only.
+-- =============================================================================
+
+-- ---------------------------------------------------------------------------
+-- 1. Tighten document_versions SELECT for carpenters
+-- ---------------------------------------------------------------------------
+drop policy "document_versions: project member can select" on public.document_versions;
+
+create policy "document_versions: project member can select"
+  on public.document_versions for select
+  using (
+    exists (
+      select 1 from public.documents d
+      where d.id = document_versions.document_id
+        and (
+          -- Admins, architects, and civil engineers see all versions
+          public.get_user_project_role(d.project_id) in ('admin', 'architect', 'civil_engineer')
+          or
+          -- Carpenters only see versions of approved documents
+          (
+            public.get_user_project_role(d.project_id) = 'carpenter'
+            and d.status = 'approved'
+          )
+        )
+    )
+  );
+
+-- ---------------------------------------------------------------------------
+-- 2. Allow civil_engineer to UPDATE documents (for status transitions)
+-- ---------------------------------------------------------------------------
+create policy "documents: civil_engineer can update status"
+  on public.documents for update
+  using (
+    public.get_user_project_role(project_id) = 'civil_engineer'
+  );


### PR DESCRIPTION
## Summary

**DB migration (`20260303150614_rbac_policies`):**
- `document_versions` SELECT policy updated: carpenters only see versions of `approved` documents; all other roles retain full project visibility
- `documents` UPDATE policy added for `civil_engineer` so they can transition status to `approved` or `changes_requested`

**`lib/auth/rbac.ts` — server-side utilities:**
- `getUserProjectRole(supabase, projectId)` — single indexed DB call via `get_user_project_role` RPC
- `requireProjectRole(supabase, projectId, ...roles)` — throws `Response(403)` if caller's role is not in the allowed list; use in Route Handlers and Server Actions
- `canTransitionDocumentStatus(role, from, to)` — pure function encoding the full transition table
- Role predicate constants: `ROLES_THAT_CAN_WRITE_DOCUMENTS`, `ROLES_THAT_CAN_REVIEW_DOCUMENTS`, `ROLES_THAT_CAN_MANAGE_MEMBERS`

**`hooks/useRole.ts` — client-side (UI-only):**
- `useRole(projectId)` — fetches role via Supabase RPC, returns `{ role, loading, error }`
- Derived hooks: `useCanWriteDocuments`, `useCanReviewDocuments`, `useCanManageMembers`, `useIsAdmin`
- All hooks explicitly documented as non-authoritative (UI gating only)

## Test plan

- [ ] Carpenter member: `document_versions` SELECT returns only versions of approved docs
- [ ] Architect member: cannot INSERT into `project_members` (403 from RLS)
- [ ] Civil engineer: can update document status to `approved` and `changes_requested`
- [ ] Architect: `canTransitionDocumentStatus('architect', 'in_review', 'approved')` returns `false`
- [ ] `requireProjectRole` throws 403 when called with insufficient role
- [ ] `useRole` returns correct role in the browser

🤖 Generated with [Claude Code](https://claude.ai/claude-code)