### PR TITLE
[6] Project creation and management

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,5 +12,9 @@ SUPABASE_SERVICE_ROLE_KEY=<service-role-key>
 ANTHROPIC_API_KEY=<anthropic-api-key>
 
 # ─── Email (Resend) ───────────────────────────────────────────────────────────
-# Get from: https://resend.com/api-keys  (used in issue #19 — Notifications)
+# Get from: https://resend.com/api-keys
 RESEND_API_KEY=<resend-api-key>
+
+# ─── App URL ──────────────────────────────────────────────────────────────────
+# Used to build invite links in emails. Set to your Vercel deployment URL in prod.
+NEXT_PUBLIC_APP_URL=http://localhost:3000

--- a/app/(auth)/sign-in/page.tsx
+++ b/app/(auth)/sign-in/page.tsx
@@ -2,6 +2,7 @@
 
 import { useActionState } from "react";
 import Link from "next/link";
+import { useSearchParams } from "next/navigation";
 import { signIn, type AuthState } from "@/lib/actions/auth";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -19,6 +20,8 @@ const initialState: AuthState = {};
 
 export default function SignInPage() {
   const [state, formAction, pending] = useActionState(signIn, initialState);
+  const searchParams = useSearchParams();
+  const redirectTo = searchParams.get("redirectTo");
 
   return (
     <Card>
@@ -31,6 +34,9 @@ export default function SignInPage() {
 
       <form action={formAction}>
         <CardContent className="space-y-4">
+          {redirectTo && (
+            <input type="hidden" name="redirectTo" value={redirectTo} />
+          )}
           {state.error && (
             <p role="alert" className="text-sm text-destructive">
               {state.error}

--- a/app/app/layout.tsx
+++ b/app/app/layout.tsx
@@ -1,0 +1,62 @@
+import Link from "next/link";
+import { redirect } from "next/navigation";
+import { createClient } from "@/lib/supabase/server";
+import { signOut } from "@/lib/actions/auth";
+import { Logo } from "@/components/logo";
+import { Button } from "@/components/ui/button";
+
+export default async function AppLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) redirect("/sign-in");
+
+  const { data: profile } = await supabase
+    .from("profiles")
+    .select("full_name")
+    .eq("id", user.id)
+    .single();
+
+  const displayName = profile?.full_name ?? user.email ?? "Account";
+
+  return (
+    <div className="min-h-screen bg-[var(--background)]">
+      <header className="sticky top-0 z-40 border-b border-border/40 bg-background/95 backdrop-blur">
+        <div className="max-w-7xl mx-auto px-6 h-14 flex items-center justify-between gap-4">
+          <div className="flex items-center gap-6">
+            <Link href="/app/projects">
+              <Logo size="sm" showWordmark />
+            </Link>
+            <nav className="hidden sm:flex items-center gap-1">
+              <Link
+                href="/app/projects"
+                className="text-sm font-medium text-muted-foreground hover:text-foreground px-3 py-1.5 rounded-md transition-colors"
+              >
+                Projects
+              </Link>
+            </nav>
+          </div>
+
+          <div className="flex items-center gap-3">
+            <span className="hidden sm:block text-sm text-muted-foreground">
+              {displayName}
+            </span>
+            <form action={signOut}>
+              <Button variant="ghost" size="sm" type="submit">
+                Sign out
+              </Button>
+            </form>
+          </div>
+        </div>
+      </header>
+
+      <main className="max-w-7xl mx-auto px-6 py-8">{children}</main>
+    </div>
+  );
+}

--- a/app/app/page.tsx
+++ b/app/app/page.tsx
@@ -1,44 +1,5 @@
 import { redirect } from "next/navigation";
-import { createClient } from "@/lib/supabase/server";
-import { signOut } from "@/lib/actions/auth";
-import { Button } from "@/components/ui/button";
-import { Logo } from "@/components/logo";
 
-export default async function AppPage() {
-  const supabase = await createClient();
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
-
-  if (!user) redirect("/sign-in");
-
-  const { data: profile } = await supabase
-    .from("profiles")
-    .select("full_name")
-    .eq("id", user.id)
-    .single();
-
-  return (
-    <div className="min-h-screen bg-[var(--background)]">
-      <header className="border-b border-border/40 bg-background/95 backdrop-blur">
-        <div className="max-w-7xl mx-auto px-6 h-14 flex items-center justify-between">
-          <Logo size="sm" showWordmark />
-          <form action={signOut}>
-            <Button variant="ghost" size="sm" type="submit">
-              Sign out
-            </Button>
-          </form>
-        </div>
-      </header>
-
-      <main className="max-w-7xl mx-auto px-6 py-12">
-        <h1 className="text-2xl font-semibold text-foreground">
-          Welcome{profile?.full_name ? `, ${profile.full_name}` : " back"}.
-        </h1>
-        <p className="mt-2 text-muted-foreground">
-          Projects and documents will appear here in issue #6.
-        </p>
-      </main>
-    </div>
-  );
+export default function AppPage() {
+  redirect("/app/projects");
 }

--- a/app/app/projects/[id]/page.tsx
+++ b/app/app/projects/[id]/page.tsx
@@ -1,0 +1,267 @@
+"use client";
+
+import { useActionState, useEffect, useState } from "react";
+import { notFound } from "next/navigation";
+import Link from "next/link";
+import { createClient } from "@/lib/supabase/client";
+import { inviteMember, type ProjectFormState } from "@/lib/actions/projects";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Badge } from "@/components/ui/badge";
+import { Separator } from "@/components/ui/separator";
+import { Avatar, AvatarFallback } from "@/components/ui/avatar";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { MapPin, Settings, UserPlus } from "lucide-react";
+import type { ProjectRole } from "@/lib/auth/rbac";
+
+const ROLE_LABELS: Record<string, string> = {
+  admin: "Admin",
+  architect: "Architect",
+  civil_engineer: "Civil Engineer",
+  carpenter: "Carpenter",
+};
+
+type Project = {
+  id: string;
+  name: string;
+  description: string | null;
+  location: string | null;
+  status: string;
+  organizations: { name: string } | null;
+};
+
+type Member = {
+  user_id: string;
+  role: string;
+  profiles: { full_name: string | null; avatar_url: string | null } | null;
+};
+
+export default function ProjectPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const [projectId, setProjectId] = useState<string | null>(null);
+  const [project, setProject] = useState<Project | null>(null);
+  const [members, setMembers] = useState<Member[]>([]);
+  const [myRole, setMyRole] = useState<ProjectRole | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [inviteRole, setInviteRole] = useState<string>("architect");
+
+  const boundInvite = projectId
+    ? inviteMember.bind(null, projectId)
+    : async () => ({});
+
+  const [inviteState, inviteAction, invitePending] = useActionState<ProjectFormState, FormData>(
+    // boundInvite is created dynamically from .bind(); cast needed as TS can't infer bound arity
+    boundInvite as (s: ProjectFormState, p: FormData) => Promise<ProjectFormState>,
+    {},
+  );
+
+  useEffect(() => {
+    params.then((p) => setProjectId(p.id));
+  }, [params]);
+
+  useEffect(() => {
+    if (!projectId) return;
+    const supabase = createClient();
+
+    async function load() {
+      const supabase = createClient();
+
+      const [{ data: proj }, { data: memberRows }, { data: { user } }] =
+        await Promise.all([
+          supabase
+            .from("projects")
+            .select("id, name, description, location, status, organizations(name)")
+            .eq("id", projectId!)
+            .single(),
+          supabase
+            .from("project_members")
+            .select("user_id, role, profiles!user_id(full_name, avatar_url)")
+            .eq("project_id", projectId!),
+          supabase.auth.getUser(),
+        ]);
+
+      if (!proj) {
+        setLoading(false);
+        return;
+      }
+
+      setProject(proj as unknown as Project);
+      setMembers((memberRows as unknown as Member[]) ?? []);
+
+      const me = memberRows?.find((m) => m.user_id === user?.id);
+      setMyRole((me?.role as ProjectRole) ?? null);
+      setLoading(false);
+    }
+
+    load();
+  }, [projectId]);
+
+  if (loading) {
+    return (
+      <div className="animate-pulse space-y-4">
+        <div className="h-8 bg-muted rounded w-48" />
+        <div className="h-4 bg-muted rounded w-96" />
+      </div>
+    );
+  }
+
+  if (!project) return notFound();
+
+  const isAdmin = myRole === "admin";
+  const initials = (name: string | null) =>
+    (name ?? "?")
+      .split(" ")
+      .map((n) => n[0])
+      .join("")
+      .toUpperCase()
+      .slice(0, 2);
+
+  return (
+    <div className="space-y-8">
+      {/* Header */}
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <h1 className="text-2xl font-semibold">{project.name}</h1>
+          {project.location && (
+            <p className="flex items-center gap-1 text-sm text-muted-foreground mt-1">
+              <MapPin className="h-3.5 w-3.5" />
+              {project.location}
+            </p>
+          )}
+          {project.description && (
+            <p className="text-sm text-muted-foreground mt-2 max-w-xl">
+              {project.description}
+            </p>
+          )}
+        </div>
+        {isAdmin && (
+          <Link href={`/app/projects/${project.id}/settings`}>
+            <Button variant="outline" size="sm">
+              <Settings className="h-4 w-4 mr-1.5" />
+              Settings
+            </Button>
+          </Link>
+        )}
+      </div>
+
+      <Separator />
+
+      {/* Members */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Members</CardTitle>
+          <CardDescription>
+            {members.length} member{members.length !== 1 ? "s" : ""} in this
+            project
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          {members.map((m) => {
+            const name = m.profiles?.full_name ?? "Unknown";
+            return (
+              <div
+                key={m.user_id}
+                className="flex items-center justify-between gap-3"
+              >
+                <div className="flex items-center gap-3">
+                  <Avatar className="h-8 w-8">
+                    <AvatarFallback className="text-xs bg-[var(--color-brand-navy)] text-white">
+                      {initials(name)}
+                    </AvatarFallback>
+                  </Avatar>
+                  <span className="text-sm font-medium">{name}</span>
+                </div>
+                <Badge variant="outline" className="text-xs">
+                  {ROLE_LABELS[m.role] ?? m.role}
+                </Badge>
+              </div>
+            );
+          })}
+        </CardContent>
+      </Card>
+
+      {/* Invite member (admin only) */}
+      {isAdmin && (
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base flex items-center gap-2">
+              <UserPlus className="h-4 w-4" />
+              Invite a member
+            </CardTitle>
+          </CardHeader>
+          <form action={inviteAction}>
+            <CardContent className="space-y-4">
+              {inviteState.error && (
+                <p role="alert" className="text-sm text-destructive">
+                  {inviteState.error}
+                </p>
+              )}
+              <div className="flex gap-3">
+                <div className="flex-1 space-y-2">
+                  <Label htmlFor="email">Email</Label>
+                  <Input
+                    id="email"
+                    name="email"
+                    type="email"
+                    required
+                    placeholder="colleague@example.com"
+                  />
+                </div>
+                <div className="space-y-2 w-44">
+                  <Label htmlFor="role">Role</Label>
+                  <Select
+                    name="role"
+                    value={inviteRole}
+                    onValueChange={setInviteRole}
+                  >
+                    <SelectTrigger id="role">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="architect">Architect</SelectItem>
+                      <SelectItem value="civil_engineer">Civil Engineer</SelectItem>
+                      <SelectItem value="carpenter">Carpenter</SelectItem>
+                      <SelectItem value="admin">Admin</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
+              </div>
+            </CardContent>
+            <CardContent className="pt-0">
+              <Button type="submit" size="sm" disabled={invitePending}>
+                {invitePending ? "Sending…" : "Send invitation"}
+              </Button>
+            </CardContent>
+          </form>
+        </Card>
+      )}
+
+      {/* Documents placeholder */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Documents</CardTitle>
+          <CardDescription>
+            Document upload and management will be available in issue #7.
+          </CardDescription>
+        </CardHeader>
+      </Card>
+    </div>
+  );
+}

--- a/app/app/projects/[id]/settings/page.tsx
+++ b/app/app/projects/[id]/settings/page.tsx
@@ -1,0 +1,183 @@
+"use client";
+
+import { useActionState, useEffect, useState } from "react";
+import { notFound, useRouter } from "next/navigation";
+import { createClient } from "@/lib/supabase/client";
+import { updateProject, archiveProject, type ProjectFormState } from "@/lib/actions/projects";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { Separator } from "@/components/ui/separator";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import type { ProjectRole } from "@/lib/auth/rbac";
+
+type Project = {
+  id: string;
+  name: string;
+  description: string | null;
+  location: string | null;
+};
+
+export default function ProjectSettingsPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const router = useRouter();
+  const [projectId, setProjectId] = useState<string | null>(null);
+  const [project, setProject] = useState<Project | null>(null);
+  const [myRole, setMyRole] = useState<ProjectRole | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [archiving, setArchiving] = useState(false);
+
+  const boundUpdate = projectId
+    ? updateProject.bind(null, projectId)
+    : async () => ({});
+
+  const [updateState, updateAction, updatePending] = useActionState<ProjectFormState, FormData>(
+    // boundUpdate is created dynamically from .bind(); cast needed as TS can't infer bound arity
+    boundUpdate as (s: ProjectFormState, p: FormData) => Promise<ProjectFormState>,
+    {},
+  );
+
+  useEffect(() => {
+    params.then((p) => setProjectId(p.id));
+  }, [params]);
+
+  useEffect(() => {
+    if (!projectId) return;
+
+    async function load() {
+      const supabase = createClient();
+      const [{ data: proj }, { data: { user } }, { data: me }] =
+        await Promise.all([
+          supabase
+            .from("projects")
+            .select("id, name, description, location")
+            .eq("id", projectId!)
+            .single(),
+          supabase.auth.getUser(),
+          supabase
+            .from("project_members")
+            .select("role")
+            .eq("project_id", projectId!)
+            .eq("user_id", (await supabase.auth.getUser()).data.user?.id ?? "")
+            .single(),
+        ]);
+
+      if (!proj) {
+        setLoading(false);
+        return;
+      }
+      setProject(proj);
+      setMyRole((me?.role as ProjectRole) ?? null);
+      setLoading(false);
+    }
+    load();
+  }, [projectId]);
+
+  if (loading) {
+    return <div className="animate-pulse h-8 bg-muted rounded w-48" />;
+  }
+  if (!project || myRole !== "admin") return notFound();
+
+  async function handleArchive() {
+    if (!projectId) return;
+    if (!confirm("Archive this project? It will be hidden from the dashboard.")) return;
+    setArchiving(true);
+    await archiveProject(projectId);
+    router.push("/app/projects");
+  }
+
+  return (
+    <div className="max-w-lg space-y-8">
+      <div>
+        <h1 className="text-2xl font-semibold">Project settings</h1>
+        <p className="text-sm text-muted-foreground mt-0.5">{project.name}</p>
+      </div>
+
+      {/* Edit metadata */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">General</CardTitle>
+        </CardHeader>
+        <form action={updateAction}>
+          <CardContent className="space-y-4">
+            {updateState.error && (
+              <p role="alert" className="text-sm text-destructive">
+                {updateState.error}
+              </p>
+            )}
+
+            <div className="space-y-2">
+              <Label htmlFor="name">Project name *</Label>
+              <Input
+                id="name"
+                name="name"
+                required
+                defaultValue={project.name}
+              />
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="location">Location</Label>
+              <Input
+                id="location"
+                name="location"
+                defaultValue={project.location ?? ""}
+              />
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="description">Description</Label>
+              <Textarea
+                id="description"
+                name="description"
+                rows={3}
+                defaultValue={project.description ?? ""}
+              />
+            </div>
+          </CardContent>
+          <CardFooter>
+            <Button type="submit" size="sm" disabled={updatePending}>
+              {updatePending ? "Saving…" : "Save changes"}
+            </Button>
+          </CardFooter>
+        </form>
+      </Card>
+
+      <Separator />
+
+      {/* Danger zone */}
+      <Card className="border-destructive/40">
+        <CardHeader>
+          <CardTitle className="text-base text-destructive">
+            Danger zone
+          </CardTitle>
+          <CardDescription>
+            Archiving hides the project from the dashboard. All data is
+            preserved.
+          </CardDescription>
+        </CardHeader>
+        <CardFooter>
+          <Button
+            variant="destructive"
+            size="sm"
+            disabled={archiving}
+            onClick={handleArchive}
+          >
+            {archiving ? "Archiving…" : "Archive project"}
+          </Button>
+        </CardFooter>
+      </Card>
+    </div>
+  );
+}

--- a/app/app/projects/join/page.tsx
+++ b/app/app/projects/join/page.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { joinProject } from "@/lib/actions/projects";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Logo } from "@/components/logo";
+
+export default function JoinProjectPage() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const token = searchParams.get("token");
+
+  const [state, setState] = useState<{
+    status: "idle" | "joining" | "success" | "error";
+    message?: string;
+    projectId?: string;
+  }>({ status: "idle" });
+
+  async function handleJoin() {
+    if (!token) return;
+    setState({ status: "joining" });
+    const result = await joinProject(token);
+    if (result.error) {
+      setState({ status: "error", message: result.error });
+    } else {
+      setState({ status: "success", projectId: result.projectId });
+    }
+  }
+
+  useEffect(() => {
+    if (state.status === "success" && state.projectId) {
+      router.push(`/app/projects/${state.projectId}`);
+    }
+  }, [state, router]);
+
+  if (!token) {
+    return (
+      <div className="min-h-screen flex items-center justify-center px-4">
+        <Card className="w-full max-w-sm text-center">
+          <CardHeader>
+            <CardTitle>Invalid invitation link</CardTitle>
+            <CardDescription>
+              This link is missing an invitation token. Please use the link from
+              your invitation email.
+            </CardDescription>
+          </CardHeader>
+        </Card>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen flex flex-col items-center justify-center bg-[var(--background)] px-4">
+      <div className="w-full max-w-sm space-y-8">
+        <div className="flex justify-center">
+          <Logo size="md" showWordmark />
+        </div>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Accept invitation</CardTitle>
+            <CardDescription>
+              You&apos;ve been invited to join a project on Bricks. Click below
+              to accept and get access.
+            </CardDescription>
+          </CardHeader>
+
+          {state.status === "error" && (
+            <CardContent>
+              <p role="alert" className="text-sm text-destructive">
+                {state.message}
+              </p>
+            </CardContent>
+          )}
+
+          <CardFooter>
+            <Button
+              className="w-full"
+              onClick={handleJoin}
+              disabled={
+                state.status === "joining" || state.status === "success"
+              }
+            >
+              {state.status === "joining"
+                ? "Joining…"
+                : state.status === "success"
+                  ? "Redirecting…"
+                  : "Accept invitation"}
+            </Button>
+          </CardFooter>
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/app/app/projects/new/page.tsx
+++ b/app/app/projects/new/page.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+import { useActionState } from "react";
+import { createProject } from "@/lib/actions/projects";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+
+export default function NewProjectPage() {
+  const [state, formAction, pending] = useActionState(createProject, {});
+
+  return (
+    <div className="max-w-lg">
+      <h1 className="text-2xl font-semibold mb-6">New project</h1>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Project details</CardTitle>
+          <CardDescription>
+            Fill in the details for your construction project.
+          </CardDescription>
+        </CardHeader>
+
+        <form action={formAction}>
+          <CardContent className="space-y-4">
+            {state.error && (
+              <p role="alert" className="text-sm text-destructive">
+                {state.error}
+              </p>
+            )}
+
+            <div className="space-y-2">
+              <Label htmlFor="name">Project name *</Label>
+              <Input
+                id="name"
+                name="name"
+                required
+                placeholder="Oslofjord Residential Block A"
+              />
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="location">Location</Label>
+              <Input
+                id="location"
+                name="location"
+                placeholder="Oslo, Norway"
+              />
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="description">Description</Label>
+              <Textarea
+                id="description"
+                name="description"
+                rows={3}
+                placeholder="Brief description of the project scope…"
+              />
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="org_name">Organization name</Label>
+              <Input
+                id="org_name"
+                name="org_name"
+                placeholder="Your company name (created on first project)"
+              />
+              <p className="text-xs text-muted-foreground">
+                Used to group your projects. Ignored if you already have an
+                organization.
+              </p>
+            </div>
+          </CardContent>
+
+          <CardFooter className="gap-3">
+            <Button type="submit" disabled={pending}>
+              {pending ? "Creating…" : "Create project"}
+            </Button>
+          </CardFooter>
+        </form>
+      </Card>
+    </div>
+  );
+}

--- a/app/app/projects/page.tsx
+++ b/app/app/projects/page.tsx
@@ -1,0 +1,115 @@
+import Link from "next/link";
+import { createClient } from "@/lib/supabase/server";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { MapPin, Plus, Users } from "lucide-react";
+
+const ROLE_LABELS: Record<string, string> = {
+  admin: "Admin",
+  architect: "Architect",
+  civil_engineer: "Civil Engineer",
+  carpenter: "Carpenter",
+};
+
+export default async function ProjectsPage() {
+  const supabase = await createClient();
+
+  // RLS ensures only the user's memberships are returned
+  const { data: memberships } = await supabase
+    .from("project_members")
+    .select(
+      `role,
+       project:project_id (
+         id, name, description, location, status, created_at
+       )`,
+    )
+    .order("created_at", { ascending: false });
+
+  const active = memberships?.filter((m) => {
+    const p = m.project as { status?: string } | null;
+    return p?.status !== "archived";
+  }) ?? [];
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-semibold">Projects</h1>
+          <p className="text-sm text-muted-foreground mt-0.5">
+            Construction projects you belong to
+          </p>
+        </div>
+        <Link href="/app/projects/new">
+          <Button size="sm">
+            <Plus className="h-4 w-4 mr-1.5" />
+            New project
+          </Button>
+        </Link>
+      </div>
+
+      {active.length === 0 ? (
+        <Card className="text-center py-16">
+          <CardContent>
+            <p className="text-muted-foreground mb-4">
+              You don&apos;t have any projects yet.
+            </p>
+            <Link href="/app/projects/new">
+              <Button>
+                <Plus className="h-4 w-4 mr-1.5" />
+                Create your first project
+              </Button>
+            </Link>
+          </CardContent>
+        </Card>
+      ) : (
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {active.map((m) => {
+            const project = m.project as {
+              id: string;
+              name: string;
+              description?: string | null;
+              location?: string | null;
+              status: string;
+            };
+            return (
+              <Link key={project.id} href={`/app/projects/${project.id}`}>
+                <Card className="h-full hover:shadow-md transition-shadow cursor-pointer">
+                  <CardHeader className="pb-2">
+                    <div className="flex items-start justify-between gap-2">
+                      <CardTitle className="text-base leading-snug">
+                        {project.name}
+                      </CardTitle>
+                      <Badge variant="outline" className="shrink-0 text-xs">
+                        {ROLE_LABELS[m.role] ?? m.role}
+                      </Badge>
+                    </div>
+                    {project.description && (
+                      <CardDescription className="line-clamp-2">
+                        {project.description}
+                      </CardDescription>
+                    )}
+                  </CardHeader>
+                  {project.location && (
+                    <CardContent className="pt-0">
+                      <span className="flex items-center gap-1 text-xs text-muted-foreground">
+                        <MapPin className="h-3 w-3" />
+                        {project.location}
+                      </span>
+                    </CardContent>
+                  )}
+                </Card>
+              </Link>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/ui/avatar.tsx
+++ b/components/ui/avatar.tsx
@@ -1,0 +1,109 @@
+"use client"
+
+import * as React from "react"
+import { Avatar as AvatarPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function Avatar({
+  className,
+  size = "default",
+  ...props
+}: React.ComponentProps<typeof AvatarPrimitive.Root> & {
+  size?: "default" | "sm" | "lg"
+}) {
+  return (
+    <AvatarPrimitive.Root
+      data-slot="avatar"
+      data-size={size}
+      className={cn(
+        "group/avatar relative flex size-8 shrink-0 overflow-hidden rounded-full select-none data-[size=lg]:size-10 data-[size=sm]:size-6",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AvatarImage({
+  className,
+  ...props
+}: React.ComponentProps<typeof AvatarPrimitive.Image>) {
+  return (
+    <AvatarPrimitive.Image
+      data-slot="avatar-image"
+      className={cn("aspect-square size-full", className)}
+      {...props}
+    />
+  )
+}
+
+function AvatarFallback({
+  className,
+  ...props
+}: React.ComponentProps<typeof AvatarPrimitive.Fallback>) {
+  return (
+    <AvatarPrimitive.Fallback
+      data-slot="avatar-fallback"
+      className={cn(
+        "flex size-full items-center justify-center rounded-full bg-muted text-sm text-muted-foreground group-data-[size=sm]/avatar:text-xs",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AvatarBadge({ className, ...props }: React.ComponentProps<"span">) {
+  return (
+    <span
+      data-slot="avatar-badge"
+      className={cn(
+        "absolute right-0 bottom-0 z-10 inline-flex items-center justify-center rounded-full bg-primary text-primary-foreground ring-2 ring-background select-none",
+        "group-data-[size=sm]/avatar:size-2 group-data-[size=sm]/avatar:[&>svg]:hidden",
+        "group-data-[size=default]/avatar:size-2.5 group-data-[size=default]/avatar:[&>svg]:size-2",
+        "group-data-[size=lg]/avatar:size-3 group-data-[size=lg]/avatar:[&>svg]:size-2",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AvatarGroup({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="avatar-group"
+      className={cn(
+        "group/avatar-group flex -space-x-2 *:data-[slot=avatar]:ring-2 *:data-[slot=avatar]:ring-background",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AvatarGroupCount({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="avatar-group-count"
+      className={cn(
+        "relative flex size-8 shrink-0 items-center justify-center rounded-full bg-muted text-sm text-muted-foreground ring-2 ring-background group-has-data-[size=lg]/avatar-group:size-10 group-has-data-[size=sm]/avatar-group:size-6 [&>svg]:size-4 group-has-data-[size=lg]/avatar-group:[&>svg]:size-5 group-has-data-[size=sm]/avatar-group:[&>svg]:size-3",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export {
+  Avatar,
+  AvatarImage,
+  AvatarFallback,
+  AvatarBadge,
+  AvatarGroup,
+  AvatarGroupCount,
+}

--- a/components/ui/select.tsx
+++ b/components/ui/select.tsx
@@ -1,0 +1,190 @@
+"use client"
+
+import * as React from "react"
+import { CheckIcon, ChevronDownIcon, ChevronUpIcon } from "lucide-react"
+import { Select as SelectPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function Select({
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Root>) {
+  return <SelectPrimitive.Root data-slot="select" {...props} />
+}
+
+function SelectGroup({
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Group>) {
+  return <SelectPrimitive.Group data-slot="select-group" {...props} />
+}
+
+function SelectValue({
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Value>) {
+  return <SelectPrimitive.Value data-slot="select-value" {...props} />
+}
+
+function SelectTrigger({
+  className,
+  size = "default",
+  children,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Trigger> & {
+  size?: "sm" | "default"
+}) {
+  return (
+    <SelectPrimitive.Trigger
+      data-slot="select-trigger"
+      data-size={size}
+      className={cn(
+        "flex w-fit items-center justify-between gap-2 rounded-md border border-input bg-transparent px-3 py-2 text-sm whitespace-nowrap shadow-xs transition-[color,box-shadow] outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 data-[placeholder]:text-muted-foreground data-[size=default]:h-9 data-[size=sm]:h-8 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 dark:bg-input/30 dark:hover:bg-input/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-muted-foreground",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <SelectPrimitive.Icon asChild>
+        <ChevronDownIcon className="size-4 opacity-50" />
+      </SelectPrimitive.Icon>
+    </SelectPrimitive.Trigger>
+  )
+}
+
+function SelectContent({
+  className,
+  children,
+  position = "item-aligned",
+  align = "center",
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Content>) {
+  return (
+    <SelectPrimitive.Portal>
+      <SelectPrimitive.Content
+        data-slot="select-content"
+        className={cn(
+          "relative z-50 max-h-(--radix-select-content-available-height) min-w-[8rem] origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border bg-popover text-popover-foreground shadow-md data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
+          position === "popper" &&
+            "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
+          className
+        )}
+        position={position}
+        align={align}
+        {...props}
+      >
+        <SelectScrollUpButton />
+        <SelectPrimitive.Viewport
+          className={cn(
+            "p-1",
+            position === "popper" &&
+              "h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)] scroll-my-1"
+          )}
+        >
+          {children}
+        </SelectPrimitive.Viewport>
+        <SelectScrollDownButton />
+      </SelectPrimitive.Content>
+    </SelectPrimitive.Portal>
+  )
+}
+
+function SelectLabel({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Label>) {
+  return (
+    <SelectPrimitive.Label
+      data-slot="select-label"
+      className={cn("px-2 py-1.5 text-xs text-muted-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+function SelectItem({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Item>) {
+  return (
+    <SelectPrimitive.Item
+      data-slot="select-item"
+      className={cn(
+        "relative flex w-full cursor-default items-center gap-2 rounded-sm py-1.5 pr-8 pl-2 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-muted-foreground *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
+        className
+      )}
+      {...props}
+    >
+      <span
+        data-slot="select-item-indicator"
+        className="absolute right-2 flex size-3.5 items-center justify-center"
+      >
+        <SelectPrimitive.ItemIndicator>
+          <CheckIcon className="size-4" />
+        </SelectPrimitive.ItemIndicator>
+      </span>
+      <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
+    </SelectPrimitive.Item>
+  )
+}
+
+function SelectSeparator({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Separator>) {
+  return (
+    <SelectPrimitive.Separator
+      data-slot="select-separator"
+      className={cn("pointer-events-none -mx-1 my-1 h-px bg-border", className)}
+      {...props}
+    />
+  )
+}
+
+function SelectScrollUpButton({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.ScrollUpButton>) {
+  return (
+    <SelectPrimitive.ScrollUpButton
+      data-slot="select-scroll-up-button"
+      className={cn(
+        "flex cursor-default items-center justify-center py-1",
+        className
+      )}
+      {...props}
+    >
+      <ChevronUpIcon className="size-4" />
+    </SelectPrimitive.ScrollUpButton>
+  )
+}
+
+function SelectScrollDownButton({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.ScrollDownButton>) {
+  return (
+    <SelectPrimitive.ScrollDownButton
+      data-slot="select-scroll-down-button"
+      className={cn(
+        "flex cursor-default items-center justify-center py-1",
+        className
+      )}
+      {...props}
+    >
+      <ChevronDownIcon className="size-4" />
+    </SelectPrimitive.ScrollDownButton>
+  )
+}
+
+export {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectScrollDownButton,
+  SelectScrollUpButton,
+  SelectSeparator,
+  SelectTrigger,
+  SelectValue,
+}

--- a/components/ui/separator.tsx
+++ b/components/ui/separator.tsx
@@ -1,0 +1,28 @@
+"use client"
+
+import * as React from "react"
+import { Separator as SeparatorPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function Separator({
+  className,
+  orientation = "horizontal",
+  decorative = true,
+  ...props
+}: React.ComponentProps<typeof SeparatorPrimitive.Root>) {
+  return (
+    <SeparatorPrimitive.Root
+      data-slot="separator"
+      decorative={decorative}
+      orientation={orientation}
+      className={cn(
+        "shrink-0 bg-border data-[orientation=horizontal]:h-px data-[orientation=horizontal]:w-full data-[orientation=vertical]:h-full data-[orientation=vertical]:w-px",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Separator }

--- a/components/ui/textarea.tsx
+++ b/components/ui/textarea.tsx
@@ -1,0 +1,18 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+function Textarea({ className, ...props }: React.ComponentProps<"textarea">) {
+  return (
+    <textarea
+      data-slot="textarea"
+      className={cn(
+        "flex field-sizing-content min-h-16 w-full rounded-md border border-input bg-transparent px-3 py-2 text-base shadow-xs transition-[color,box-shadow] outline-none placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 md:text-sm dark:bg-input/30 dark:aria-invalid:ring-destructive/40",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Textarea }

--- a/lib/actions/auth.ts
+++ b/lib/actions/auth.ts
@@ -64,7 +64,8 @@ export async function signIn(
   }
 
   revalidatePath("/", "layout");
-  redirect("/app");
+  const redirectTo = formData.get("redirectTo") as string | null;
+  redirect(redirectTo ?? "/app");
 }
 
 export async function signOut(): Promise<void> {

--- a/lib/actions/projects.ts
+++ b/lib/actions/projects.ts
@@ -1,0 +1,256 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { redirect } from "next/navigation";
+import { createClient } from "@/lib/supabase/server";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { requireProjectRole } from "@/lib/auth/rbac";
+import { sendProjectInviteEmail } from "@/lib/email/resend";
+import type { ProjectRole } from "@/lib/auth/rbac";
+
+export type ProjectFormState = {
+  error?: string;
+  fieldErrors?: Record<string, string>;
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function slugify(name: string): string {
+  return (
+    name
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, "-")
+      .replace(/^-|-$/g, "")
+      .slice(0, 48) +
+    "-" +
+    Math.random().toString(36).slice(2, 6)
+  );
+}
+
+// ---------------------------------------------------------------------------
+// createProject
+// Uses the create_project() DB function to atomically create the project
+// and add the creator as admin (bypasses the project_members RLS bootstrap).
+// Organization is created if the user has none.
+// ---------------------------------------------------------------------------
+export async function createProject(
+  _prevState: ProjectFormState,
+  formData: FormData,
+): Promise<ProjectFormState> {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) redirect("/sign-in");
+
+  const name = (formData.get("name") as string).trim();
+  const description = (formData.get("description") as string | null)?.trim() ?? null;
+  const location = (formData.get("location") as string | null)?.trim() ?? null;
+  const orgName = (formData.get("org_name") as string | null)?.trim();
+
+  if (!name) return { error: "Project name is required." };
+
+  // Resolve or create the organization
+  let orgId: string | null = null;
+
+  const { data: existingOrg } = await supabase
+    .from("organizations")
+    .select("id")
+    .eq("created_by", user.id)
+    .limit(1)
+    .single();
+
+  if (existingOrg) {
+    orgId = existingOrg.id;
+  } else {
+    // Create a new org using the SECURITY DEFINER function
+    const resolvedOrgName = orgName || "My Organization";
+    const { data: newOrgId, error: orgError } = await supabase.rpc(
+      "create_organization",
+      { p_name: resolvedOrgName, p_slug: slugify(resolvedOrgName) },
+    );
+    if (orgError || !newOrgId) {
+      return { error: "Could not create organization. Please try again." };
+    }
+    orgId = newOrgId as string;
+  }
+
+  // Create project + add creator as admin atomically
+  const { data: projectId, error: projectError } = await supabase.rpc(
+    "create_project",
+    {
+      p_organization_id: orgId,
+      p_name: name,
+      p_description: description ?? "",
+      p_location: location ?? "",
+    },
+  );
+
+  if (projectError || !projectId) {
+    return { error: "Could not create project. Please try again." };
+  }
+
+  revalidatePath("/app/projects");
+  redirect(`/app/projects/${projectId}`);
+}
+
+// ---------------------------------------------------------------------------
+// updateProject
+// ---------------------------------------------------------------------------
+export async function updateProject(
+  projectId: string,
+  _prevState: ProjectFormState,
+  formData: FormData,
+): Promise<ProjectFormState> {
+  const supabase = await createClient();
+  await requireProjectRole(supabase, projectId, "admin");
+
+  const name = (formData.get("name") as string).trim();
+  const description = (formData.get("description") as string | null)?.trim() ?? null;
+  const location = (formData.get("location") as string | null)?.trim() ?? null;
+
+  if (!name) return { error: "Project name is required." };
+
+  const { error } = await supabase
+    .from("projects")
+    .update({ name, description, location, updated_at: new Date().toISOString() })
+    .eq("id", projectId);
+
+  if (error) return { error: "Could not update project. Please try again." };
+
+  revalidatePath(`/app/projects/${projectId}`);
+  revalidatePath(`/app/projects/${projectId}/settings`);
+  return {};
+}
+
+// ---------------------------------------------------------------------------
+// archiveProject
+// ---------------------------------------------------------------------------
+export async function archiveProject(projectId: string): Promise<void> {
+  const supabase = await createClient();
+  await requireProjectRole(supabase, projectId, "admin");
+
+  await supabase
+    .from("projects")
+    .update({ status: "archived", updated_at: new Date().toISOString() })
+    .eq("id", projectId);
+
+  revalidatePath("/app/projects");
+  redirect("/app/projects");
+}
+
+// ---------------------------------------------------------------------------
+// inviteMember
+// ---------------------------------------------------------------------------
+export async function inviteMember(
+  projectId: string,
+  _prevState: ProjectFormState,
+  formData: FormData,
+): Promise<ProjectFormState> {
+  const supabase = await createClient();
+  await requireProjectRole(supabase, projectId, "admin");
+
+  const email = (formData.get("email") as string).trim().toLowerCase();
+  const role = formData.get("role") as ProjectRole;
+
+  if (!email) return { error: "Email is required." };
+  if (!role) return { error: "Role is required." };
+
+  // Get inviter profile for the email
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  const { data: profile } = await supabase
+    .from("profiles")
+    .select("full_name")
+    .eq("id", user!.id)
+    .single();
+
+  const { data: project } = await supabase
+    .from("projects")
+    .select("name")
+    .eq("id", projectId)
+    .single();
+
+  if (!project) return { error: "Project not found." };
+
+  // Create the invite token
+  const admin = createAdminClient();
+  const { data: invite, error: inviteError } = await admin
+    .from("project_invites")
+    .insert({
+      project_id: projectId,
+      email,
+      role,
+      invited_by: user!.id,
+    })
+    .select("token")
+    .single();
+
+  if (inviteError || !invite) {
+    return { error: "Could not create invite. Please try again." };
+  }
+
+  // Send invite email
+  try {
+    await sendProjectInviteEmail({
+      to: email,
+      inviterName: profile?.full_name ?? "A team member",
+      projectName: project.name,
+      role,
+      token: invite.token,
+    });
+  } catch {
+    // Clean up the invite if email fails
+    await admin.from("project_invites").delete().eq("token", invite.token);
+    return {
+      error: "Could not send invite email. Please check the address and try again.",
+    };
+  }
+
+  revalidatePath(`/app/projects/${projectId}`);
+  return { error: undefined };
+}
+
+// ---------------------------------------------------------------------------
+// joinProject — validates token and adds user to project
+// ---------------------------------------------------------------------------
+export async function joinProject(token: string): Promise<{ error?: string; projectId?: string }> {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) redirect("/sign-in");
+
+  const admin = createAdminClient();
+
+  const { data: invite, error } = await admin
+    .from("project_invites")
+    .select("id, project_id, email, role, expires_at, used_at")
+    .eq("token", token)
+    .single();
+
+  if (error || !invite) return { error: "Invalid or expired invitation." };
+  if (invite.used_at) return { error: "This invitation has already been used." };
+  if (new Date(invite.expires_at) < new Date())
+    return { error: "This invitation has expired. Please ask for a new one." };
+
+  // Add member — use admin client to bypass RLS on project_members for non-admin actors
+  const { error: memberError } = await admin.from("project_members").upsert(
+    { project_id: invite.project_id, user_id: user.id, role: invite.role },
+    { onConflict: "project_id,user_id" },
+  );
+
+  if (memberError) return { error: "Could not join project. Please try again." };
+
+  // Mark invite as used
+  await admin
+    .from("project_invites")
+    .update({ used_at: new Date().toISOString() })
+    .eq("id", invite.id);
+
+  revalidatePath("/app/projects");
+  return { projectId: invite.project_id };
+}

--- a/lib/email/resend.ts
+++ b/lib/email/resend.ts
@@ -1,0 +1,63 @@
+import { Resend } from "resend";
+
+const resend = new Resend(process.env.RESEND_API_KEY);
+
+const APP_URL =
+  process.env.NEXT_PUBLIC_APP_URL ?? "http://localhost:3000";
+
+const FROM = "Bricks <noreply@bricks.build>";
+
+export async function sendProjectInviteEmail({
+  to,
+  inviterName,
+  projectName,
+  role,
+  token,
+}: {
+  to: string;
+  inviterName: string;
+  projectName: string;
+  role: string;
+  token: string;
+}) {
+  const joinUrl = `${APP_URL}/app/projects/join?token=${token}`;
+  const roleLabel = role.replace(/_/g, " ");
+
+  const { error } = await resend.emails.send({
+    from: FROM,
+    to,
+    subject: `You've been invited to join "${projectName}" on Bricks`,
+    html: `
+      <div style="font-family:sans-serif;max-width:560px;margin:0 auto;color:#1a1a1a">
+        <div style="background:#0F2D5E;padding:24px 32px">
+          <span style="color:#fff;font-size:20px;font-weight:700;letter-spacing:-0.5px">Bricks</span>
+        </div>
+        <div style="padding:32px">
+          <h1 style="font-size:22px;font-weight:600;margin:0 0 12px">
+            You've been invited to join a project
+          </h1>
+          <p style="color:#555;margin:0 0 24px">
+            <strong>${inviterName}</strong> has invited you to join
+            <strong>${projectName}</strong> as a <strong>${roleLabel}</strong>.
+          </p>
+          <a href="${joinUrl}"
+             style="display:inline-block;background:#C45C3A;color:#fff;text-decoration:none;
+                    padding:12px 24px;border-radius:6px;font-weight:600;font-size:15px">
+            Accept invitation
+          </a>
+          <p style="color:#888;font-size:13px;margin:24px 0 0">
+            This invitation expires in 7 days. If you don't have a Bricks account,
+            you'll be asked to create one first.
+          </p>
+          <p style="color:#bbb;font-size:12px;margin:8px 0 0">
+            Or copy this link: ${joinUrl}
+          </p>
+        </div>
+      </div>
+    `,
+  });
+
+  if (error) {
+    throw new Error(`Failed to send invite email: ${error.message}`);
+  }
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -32,10 +32,13 @@ export async function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl;
 
   // Redirect unauthenticated users away from protected routes.
+  // Preserve the original path so invite links survive the sign-in redirect.
   const isProtectedRoute = pathname.startsWith("/app");
   if (isProtectedRoute && !user) {
     const url = request.nextUrl.clone();
+    const redirectTo = pathname + request.nextUrl.search;
     url.pathname = "/sign-in";
+    url.searchParams.set("redirectTo", redirectTo);
     return NextResponse.redirect(url);
   }
 
@@ -43,8 +46,10 @@ export async function middleware(request: NextRequest) {
   const isAuthRoute =
     pathname.startsWith("/sign-in") || pathname.startsWith("/sign-up");
   if (isAuthRoute && user) {
+    const redirectTo = request.nextUrl.searchParams.get("redirectTo");
     const url = request.nextUrl.clone();
-    url.pathname = "/app";
+    url.pathname = redirectTo ?? "/app";
+    url.search = "";
     return NextResponse.redirect(url);
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "radix-ui": "^1.4.3",
         "react": "19.2.3",
         "react-dom": "19.2.3",
+        "resend": "^6.9.3",
         "tailwind-merge": "^3.5.0"
       },
       "devDependencies": {
@@ -3478,6 +3479,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
+      "license": "MIT"
+    },
     "node_modules/@supabase/auth-js": {
       "version": "2.98.0",
       "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.98.0.tgz",
@@ -6727,6 +6734,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+      "license": "Unlicense"
+    },
     "node_modules/fast-uri": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
@@ -9570,6 +9583,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/postal-mime": {
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/postal-mime/-/postal-mime-2.7.3.tgz",
+      "integrity": "sha512-MjhXadAJaWgYzevi46+3kLak8y6gbg0ku14O1gO/LNOuay8dO+1PtcSGvAdgDR0DoIsSaiIA8y/Ddw6MnrO0Tw==",
+      "license": "MIT-0"
+    },
     "node_modules/postcss": {
       "version": "8.5.8",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
@@ -10123,6 +10142,27 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resend": {
+      "version": "6.9.3",
+      "resolved": "https://registry.npmjs.org/resend/-/resend-6.9.3.tgz",
+      "integrity": "sha512-GRXjH9XZBJA+daH7bBVDuTShr22iWCxXA8P7t495G4dM/RC+d+3gHBK/6bz9K6Vpcq11zRQKmD+B+jECwQlyGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "postal-mime": "2.7.3",
+        "svix": "1.84.1"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@react-email/render": "*"
+      },
+      "peerDependenciesMeta": {
+        "@react-email/render": {
+          "optional": true
+        }
       }
     },
     "node_modules/resolve": {
@@ -10752,6 +10792,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/standardwebhooks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
+      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "fast-sha256": "^1.3.0"
+      }
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -11051,6 +11101,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/svix": {
+      "version": "1.84.1",
+      "resolved": "https://registry.npmjs.org/svix/-/svix-1.84.1.tgz",
+      "integrity": "sha512-K8DPPSZaW/XqXiz1kEyzSHYgmGLnhB43nQCMeKjWGCUpLIpAMMM8kx3rVVOSm6Bo6EHyK1RQLPT4R06skM/MlQ==",
+      "license": "MIT",
+      "dependencies": {
+        "standardwebhooks": "1.0.0",
+        "uuid": "^10.0.0"
       }
     },
     "node_modules/tagged-tag": {
@@ -11646,6 +11706,19 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
     },
     "node_modules/validate-npm-package-name": {
       "version": "7.0.2",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "radix-ui": "^1.4.3",
     "react": "19.2.3",
     "react-dom": "19.2.3",
+    "resend": "^6.9.3",
     "tailwind-merge": "^3.5.0"
   },
   "devDependencies": {

--- a/supabase/migrations/20260303151430_project_invites.sql
+++ b/supabase/migrations/20260303151430_project_invites.sql
@@ -1,0 +1,104 @@
+-- =============================================================================
+-- Bricks — Project invites
+-- Migration: 20260303151430_project_invites
+-- =============================================================================
+-- Adds:
+--   • project_invites table — single-use, 7-day invite tokens
+--   • create_project() SECURITY DEFINER function — bootstraps creator as admin
+--     in a single transaction, bypassing the project_members RLS chicken-and-egg
+-- =============================================================================
+
+-- ---------------------------------------------------------------------------
+-- project_invites
+-- ---------------------------------------------------------------------------
+create table public.project_invites (
+  id          uuid        primary key default gen_random_uuid(),
+  project_id  uuid        not null references public.projects(id) on delete cascade,
+  email       text        not null,
+  role        public.project_role not null,
+  invited_by  uuid        not null references auth.users(id) on delete restrict,
+  token       uuid        not null unique default gen_random_uuid(),
+  expires_at  timestamptz not null default (now() + interval '7 days'),
+  used_at     timestamptz,
+  created_at  timestamptz not null default now()
+);
+
+comment on table public.project_invites is
+  'Single-use invite tokens. Expire after 7 days. Validated via service role.';
+
+create index on public.project_invites (token);
+create index on public.project_invites (project_id);
+
+alter table public.project_invites enable row level security;
+
+-- Only admins can create invites for their project
+create policy "project_invites: admin can insert"
+  on public.project_invites for insert
+  with check (
+    public.get_user_project_role(project_id) = 'admin'
+    and invited_by = auth.uid()
+  );
+
+-- Admins can view pending invites for their project
+create policy "project_invites: admin can select"
+  on public.project_invites for select
+  using (
+    public.get_user_project_role(project_id) = 'admin'
+  );
+
+-- ---------------------------------------------------------------------------
+-- create_project()
+-- Creates a project and atomically adds the calling user as admin.
+-- Uses SECURITY DEFINER to bypass the project_members RLS bootstrapping
+-- problem (no members exist yet when the first member row is inserted).
+-- ---------------------------------------------------------------------------
+create or replace function public.create_project(
+  p_organization_id uuid,
+  p_name            text,
+  p_description     text,
+  p_location        text
+)
+returns uuid
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_project_id uuid;
+begin
+  -- Insert the project (created_by = calling user via auth.uid())
+  insert into public.projects (organization_id, name, description, location, created_by)
+  values (p_organization_id, p_name, p_description, p_location, auth.uid())
+  returning id into v_project_id;
+
+  -- Add calling user as admin (bypasses project_members RLS bootstrap issue)
+  insert into public.project_members (project_id, user_id, role)
+  values (v_project_id, auth.uid(), 'admin');
+
+  return v_project_id;
+end;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- create_organization()
+-- Creates an organization for the calling user.
+-- ---------------------------------------------------------------------------
+create or replace function public.create_organization(
+  p_name text,
+  p_slug text
+)
+returns uuid
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_org_id uuid;
+begin
+  insert into public.organizations (name, slug, created_by)
+  values (p_name, p_slug, auth.uid())
+  returning id into v_org_id;
+
+  return v_org_id;
+end;
+$$;

--- a/types/database.ts
+++ b/types/database.ts
@@ -12,31 +12,6 @@ export type Database = {
   __InternalSupabase: {
     PostgrestVersion: "14.1"
   }
-  graphql_public: {
-    Tables: {
-      [_ in never]: never
-    }
-    Views: {
-      [_ in never]: never
-    }
-    Functions: {
-      graphql: {
-        Args: {
-          extensions?: Json
-          operationName?: string
-          query?: string
-          variables?: Json
-        }
-        Returns: Json
-      }
-    }
-    Enums: {
-      [_ in never]: never
-    }
-    CompositeTypes: {
-      [_ in never]: never
-    }
-  }
   public: {
     Tables: {
       comments: {
@@ -286,6 +261,50 @@ export type Database = {
         }
         Relationships: []
       }
+      project_invites: {
+        Row: {
+          created_at: string
+          email: string
+          expires_at: string
+          id: string
+          invited_by: string
+          project_id: string
+          role: Database["public"]["Enums"]["project_role"]
+          token: string
+          used_at: string | null
+        }
+        Insert: {
+          created_at?: string
+          email: string
+          expires_at?: string
+          id?: string
+          invited_by: string
+          project_id: string
+          role: Database["public"]["Enums"]["project_role"]
+          token?: string
+          used_at?: string | null
+        }
+        Update: {
+          created_at?: string
+          email?: string
+          expires_at?: string
+          id?: string
+          invited_by?: string
+          project_id?: string
+          role?: Database["public"]["Enums"]["project_role"]
+          token?: string
+          used_at?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "project_invites_project_id_fkey"
+            columns: ["project_id"]
+            isOneToOne: false
+            referencedRelation: "projects"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       project_members: {
         Row: {
           created_at: string
@@ -370,6 +389,19 @@ export type Database = {
       [_ in never]: never
     }
     Functions: {
+      create_organization: {
+        Args: { p_name: string; p_slug: string }
+        Returns: string
+      }
+      create_project: {
+        Args: {
+          p_description: string
+          p_location: string
+          p_name: string
+          p_organization_id: string
+        }
+        Returns: string
+      }
       get_user_project_role: {
         Args: { p_project_id: string }
         Returns: Database["public"]["Enums"]["project_role"]
@@ -511,9 +543,6 @@ export type CompositeTypes<
     : never
 
 export const Constants = {
-  graphql_public: {
-    Enums: {},
-  },
   public: {
     Enums: {
       document_content_type: ["file", "rich_text"],


### PR DESCRIPTION
## Summary

**DB migration (`20260303151430_project_invites`):**
- `project_invites` table — single-use tokens, 7-day expiry, admin-only RLS
- `create_project()` SECURITY DEFINER RPC — atomically creates project + admin membership (solves RLS bootstrap problem)
- `create_organization()` SECURITY DEFINER RPC — creates org for user

**Pages added:**
| Route | Description |
|---|---|
| `/app/projects` | Dashboard — lists all active projects with role badge |
| `/app/projects/new` | Create project form (auto-creates org if user has none) |
| `/app/projects/[id]` | Project detail — members list + invite form (admin only) |
| `/app/projects/[id]/settings` | Edit metadata, archive project (admin only, returns 404 for non-admins) |
| `/app/projects/join?token=` | Accept invite — validates token, adds user, redirects to project |

**Other:**
- Shared `app/app/layout.tsx` nav header (replaces per-page headers)
- `lib/email/resend.ts` — branded HTML invite email via Resend
- `middleware.ts` — `redirectTo` param preserved so invite links survive unauthenticated redirect
- `signIn` action honours `redirectTo` after success
- `types/database.ts` regenerated with `project_invites` and new RPC functions

## Test plan

- [ ] Create project → appears in dashboard → creator has admin role
- [ ] Invite member by email → receives branded email with join link
- [ ] Non-registered invitee → redirected to sign-up → after verification, join link works
- [ ] Expired token → clear error message
- [ ] Already-used token → clear error message
- [ ] Non-admin visiting `/settings` → 404
- [ ] Archive project → disappears from active dashboard
- [ ] Edit project name/location → saved correctly

🤖 Generated with [Claude Code](https://claude.ai/claude-code)