### PR TITLE
feat: document review and approval workflow (#11)

### DIFF
--- a/app/app/projects/[id]/documents/[docId]/edit/page.tsx
+++ b/app/app/projects/[id]/documents/[docId]/edit/page.tsx
@@ -34,6 +34,11 @@ export default async function EditDocumentPage({
 
   if (!doc) return notFound();
 
+  // Approved documents are immutable — redirect to viewer
+  if (doc.status === "approved") {
+    redirect(`/app/projects/${projectId}/documents/${docId}`);
+  }
+
   // Fetch latest rich_text version (if any)
   const admin = createAdminClient();
   const { data: version } = await admin

--- a/app/app/projects/[id]/documents/[docId]/page.tsx
+++ b/app/app/projects/[id]/documents/[docId]/page.tsx
@@ -97,6 +97,7 @@ export default async function DocumentPage({
       projectId={projectId}
       canEdit={canEdit}
       currentUserId={user.id}
+      userRole={role ?? "carpenter"}
     />
   );
 }

--- a/components/document-status-actions.tsx
+++ b/components/document-status-actions.tsx
@@ -1,0 +1,147 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { CheckCircle, Clock, Send, XCircle } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import { transitionDocumentStatus } from "@/lib/actions/workflow";
+import { getAvailableTransitions, type ProjectRole, type DocumentStatus } from "@/lib/auth/rbac";
+
+const ACTION_LABELS: Partial<Record<DocumentStatus, string>> = {
+  in_review: "Submit for Review",
+  approved: "Approve",
+  changes_requested: "Request Changes",
+  submitted: "Submit to Authorities",
+};
+
+const ACTION_ICONS: Partial<Record<DocumentStatus, React.ReactNode>> = {
+  in_review: <Send className="h-3.5 w-3.5 mr-1.5" />,
+  approved: <CheckCircle className="h-3.5 w-3.5 mr-1.5" />,
+  changes_requested: <XCircle className="h-3.5 w-3.5 mr-1.5" />,
+  submitted: <Clock className="h-3.5 w-3.5 mr-1.5" />,
+};
+
+const ACTION_VARIANTS: Partial<Record<DocumentStatus, "default" | "outline" | "destructive">> = {
+  in_review: "default",
+  approved: "default",
+  changes_requested: "outline",
+  submitted: "outline",
+};
+
+interface DocumentStatusActionsProps {
+  docId: string;
+  projectId: string;
+  currentStatus: DocumentStatus;
+  userRole: ProjectRole;
+}
+
+export function DocumentStatusActions({
+  docId,
+  projectId,
+  currentStatus,
+  userRole,
+}: DocumentStatusActionsProps) {
+  const router = useRouter();
+  const [isPending, setIsPending] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // "Request Changes" note form state
+  const [showNoteForm, setShowNoteForm] = useState(false);
+  const [note, setNote] = useState("");
+
+  const availableTransitions = getAvailableTransitions(userRole, currentStatus);
+
+  if (availableTransitions.length === 0) return null;
+
+  async function handleTransition(newStatus: DocumentStatus, noteText?: string) {
+    setIsPending(true);
+    setError(null);
+    const result = await transitionDocumentStatus(docId, projectId, newStatus, noteText);
+    setIsPending(false);
+    if (result.error) {
+      setError(result.error);
+    } else {
+      setShowNoteForm(false);
+      setNote("");
+      router.refresh();
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-2">
+      {/* Action buttons */}
+      <div className="flex items-center gap-2 flex-wrap">
+        {availableTransitions.map((target) => {
+          if (target === "changes_requested") {
+            // Show inline note form instead of immediately transitioning
+            return showNoteForm ? null : (
+              <Button
+                key={target}
+                size="sm"
+                variant={ACTION_VARIANTS[target] ?? "outline"}
+                disabled={isPending}
+                onClick={() => setShowNoteForm(true)}
+              >
+                {ACTION_ICONS[target]}
+                {ACTION_LABELS[target]}
+              </Button>
+            );
+          }
+          return (
+            <Button
+              key={target}
+              size="sm"
+              variant={ACTION_VARIANTS[target] ?? "default"}
+              disabled={isPending}
+              onClick={() => handleTransition(target)}
+            >
+              {ACTION_ICONS[target]}
+              {isPending ? "Updating…" : ACTION_LABELS[target]}
+            </Button>
+          );
+        })}
+      </div>
+
+      {/* Inline "Request Changes" note form */}
+      {showNoteForm && (
+        <div className="rounded-md border p-3 bg-muted/30 space-y-2">
+          <p className="text-xs font-medium">Describe what needs to change</p>
+          <Textarea
+            autoFocus
+            value={note}
+            onChange={(e) => setNote(e.target.value)}
+            placeholder="Explain what changes are required…"
+            rows={3}
+            className="text-sm resize-none"
+          />
+          <div className="flex gap-2">
+            <Button
+              size="sm"
+              variant="destructive"
+              className="h-7 text-xs"
+              disabled={isPending || !note.trim()}
+              onClick={() => handleTransition("changes_requested", note)}
+            >
+              {isPending ? "Sending…" : "Request Changes"}
+            </Button>
+            <Button
+              size="sm"
+              variant="ghost"
+              className="h-7 text-xs"
+              disabled={isPending}
+              onClick={() => {
+                setShowNoteForm(false);
+                setNote("");
+              }}
+            >
+              Cancel
+            </Button>
+          </div>
+        </div>
+      )}
+
+      {error && <p className="text-xs text-destructive">{error}</p>}
+    </div>
+  );
+}

--- a/components/document-viewer-client.tsx
+++ b/components/document-viewer-client.tsx
@@ -18,6 +18,8 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Separator } from "@/components/ui/separator";
 import { cn } from "@/lib/utils";
 import { CommentThread } from "@/components/comment-thread";
+import { DocumentStatusActions } from "@/components/document-status-actions";
+import type { ProjectRole, DocumentStatus } from "@/lib/auth/rbac";
 
 const STATUS_LABELS: Record<string, string> = {
   draft: "Draft",
@@ -79,6 +81,7 @@ interface DocumentViewerClientProps {
   projectId: string;
   canEdit: boolean;
   currentUserId: string;
+  userRole: ProjectRole;
 }
 
 const DWG_MIMES = new Set([
@@ -99,6 +102,7 @@ export function DocumentViewerClient({
   projectId,
   canEdit,
   currentUserId,
+  userRole,
 }: DocumentViewerClientProps) {
   const [selectedVersionId, setSelectedVersionId] = useState(initialVersionId);
   const [content, setContent] = useState<LoadedContent>(initialContent);
@@ -173,10 +177,16 @@ export function DocumentViewerClient({
           <Badge variant="outline" className="text-xs">
             {STATUS_LABELS[document.status] ?? document.status}
           </Badge>
+          <DocumentStatusActions
+            docId={document.id}
+            projectId={projectId}
+            currentStatus={document.status as DocumentStatus}
+            userRole={userRole}
+          />
         </div>
 
         <div className="flex items-center gap-2">
-          {canEdit && isRichText && (
+          {canEdit && isRichText && document.status !== "approved" && (
             <>
               <Button variant="ghost" size="sm" onClick={openPdfExport}>
                 <FileDown className="h-4 w-4 mr-1.5" />
@@ -189,6 +199,12 @@ export function DocumentViewerClient({
                 </Link>
               </Button>
             </>
+          )}
+          {canEdit && isRichText && document.status === "approved" && (
+            <Button variant="ghost" size="sm" onClick={openPdfExport}>
+              <FileDown className="h-4 w-4 mr-1.5" />
+              Export PDF
+            </Button>
           )}
           {!isRichText && selectedVersion.storage_path && (
             <Button variant="outline" size="sm" onClick={download}>

--- a/lib/actions/documents.ts
+++ b/lib/actions/documents.ts
@@ -59,6 +59,17 @@ export async function saveDocumentVersion(
 
   const admin = createAdminClient();
 
+  // Approved documents are immutable — no new versions allowed
+  const { data: docCheck } = await admin
+    .from("documents")
+    .select("status")
+    .eq("id", docId)
+    .single();
+
+  if (docCheck?.status === "approved") {
+    return { error: "Approved documents cannot be edited. Create a new version." };
+  }
+
   const { data: latestVersion } = await admin
     .from("document_versions")
     .select("version_number")

--- a/lib/actions/workflow.ts
+++ b/lib/actions/workflow.ts
@@ -1,0 +1,197 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { createClient } from "@/lib/supabase/server";
+import { createAdminClient } from "@/lib/supabase/admin";
+import {
+  getUserProjectRole,
+  canTransitionDocumentStatus,
+  type DocumentStatus,
+} from "@/lib/auth/rbac";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { Database } from "@/types/database";
+
+const STATUS_LABELS: Record<DocumentStatus, string> = {
+  draft: "Draft",
+  in_review: "In Review",
+  approved: "Approved",
+  changes_requested: "Changes Requested",
+  submitted: "Submitted",
+};
+
+// ---------------------------------------------------------------------------
+// transitionDocumentStatus
+// Validates the role-gated transition, updates documents.status, writes the
+// mandatory audit log, and fires non-blocking in-app notifications.
+// ---------------------------------------------------------------------------
+export async function transitionDocumentStatus(
+  docId: string,
+  projectId: string,
+  newStatus: DocumentStatus,
+  note?: string,
+): Promise<{ error?: string }> {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return { error: "Unauthorized" };
+
+  const role = await getUserProjectRole(supabase, projectId);
+  if (!role) return { error: "Not a project member" };
+
+  const admin = createAdminClient();
+
+  const { data: doc } = await admin
+    .from("documents")
+    .select("id, title, status, created_by")
+    .eq("id", docId)
+    .single();
+
+  if (!doc) return { error: "Document not found" };
+
+  const fromStatus = doc.status as DocumentStatus;
+
+  if (!canTransitionDocumentStatus(role, fromStatus, newStatus)) {
+    return { error: "This status transition is not permitted for your role" };
+  }
+
+  if (newStatus === "changes_requested" && !note?.trim()) {
+    return { error: "Please provide a comment when requesting changes" };
+  }
+
+  // Update document status
+  const { error: updateError } = await admin
+    .from("documents")
+    .update({ status: newStatus, updated_at: new Date().toISOString() })
+    .eq("id", docId);
+
+  if (updateError) return { error: "Could not update document status" };
+
+  // Write audit log — mandatory; log failure but don't surface to user since
+  // the transition has already been committed.
+  const { error: auditError } = await admin
+    .from("document_status_history")
+    .insert({
+      document_id: docId,
+      from_status: fromStatus,
+      to_status: newStatus,
+      changed_by: user.id,
+      note: note?.trim() ?? null,
+    });
+
+  if (auditError) {
+    console.error("Audit log write failed:", auditError);
+  }
+
+  // Non-blocking notifications
+  void sendWorkflowNotifications({
+    admin,
+    docId,
+    projectId,
+    docTitle: doc.title,
+    newStatus,
+    actorId: user.id,
+    documentCreatedBy: doc.created_by,
+    note,
+  }).catch((err) => {
+    console.error("Workflow notification failed:", err);
+  });
+
+  console.log("Document status changed:", {
+    docId,
+    from: fromStatus,
+    to: newStatus,
+    actorId: user.id,
+  });
+
+  revalidatePath(`/app/projects/${projectId}/documents/${docId}`);
+  revalidatePath(`/app/projects/${projectId}`);
+  return {};
+}
+
+// ---------------------------------------------------------------------------
+// Notification helpers
+// ---------------------------------------------------------------------------
+async function sendWorkflowNotifications({
+  admin,
+  docId,
+  projectId,
+  docTitle,
+  newStatus,
+  actorId,
+  documentCreatedBy,
+  note,
+}: {
+  admin: SupabaseClient<Database>;
+  docId: string;
+  projectId: string;
+  docTitle: string;
+  newStatus: DocumentStatus;
+  actorId: string;
+  documentCreatedBy: string;
+  note?: string;
+}) {
+  const link = `/app/projects/${projectId}/documents/${docId}`;
+
+  // Get actor name
+  const { data: actorProfile } = await admin
+    .from("profiles")
+    .select("full_name")
+    .eq("id", actorId)
+    .single();
+  const actorName = actorProfile?.full_name ?? "Someone";
+
+  if (newStatus === "in_review") {
+    // Notify all civil_engineers and admins in the project (reviewers)
+    const { data: reviewers } = await admin
+      .from("project_members")
+      .select("user_id, role")
+      .eq("project_id", projectId)
+      .in("role", ["civil_engineer", "admin"]);
+
+    const recipientIds = (reviewers ?? [])
+      .map((r) => r.user_id)
+      .filter((id) => id !== actorId);
+
+    if (recipientIds.length > 0) {
+      const notifClient = admin as any;
+      await notifClient.from("notifications").insert(
+        recipientIds.map((userId: string) => ({
+          user_id: userId,
+          type: "status_change",
+          title: `"${docTitle}" is ready for review`,
+          body: `${actorName} submitted the document for review.`,
+          link,
+        })),
+      );
+    }
+    return;
+  }
+
+  // For approved / changes_requested — notify the document creator
+  if (
+    (newStatus === "approved" || newStatus === "changes_requested") &&
+    documentCreatedBy !== actorId
+  ) {
+    const title =
+      newStatus === "approved"
+        ? `"${docTitle}" was approved`
+        : `Changes requested on "${docTitle}"`;
+
+    const body =
+      newStatus === "approved"
+        ? `${actorName} approved the document.`
+        : `${actorName} requested changes${note?.trim() ? `: ${note.trim().slice(0, 200)}` : "."}`;
+
+    const notifClient = admin as any;
+    await notifClient.from("notifications").insert([
+      {
+        user_id: documentCreatedBy,
+        type: "status_change",
+        title,
+        body,
+        link,
+      },
+    ]);
+  }
+}

--- a/lib/auth/rbac.ts
+++ b/lib/auth/rbac.ts
@@ -121,3 +121,16 @@ export const ROLES_THAT_CAN_REVIEW_DOCUMENTS: ProjectRole[] = [
 ];
 
 export const ROLES_THAT_CAN_MANAGE_MEMBERS: ProjectRole[] = ["admin"];
+
+/**
+ * Returns the list of statuses a given role can transition a document to,
+ * given its current status. Pure function — safe to use in client components.
+ */
+export function getAvailableTransitions(
+  role: ProjectRole,
+  fromStatus: DocumentStatus,
+): DocumentStatus[] {
+  return ALLOWED_TRANSITIONS[role]
+    .filter((t) => t.from === fromStatus)
+    .map((t) => t.to);
+}


### PR DESCRIPTION
## Summary

- Role-gated status transitions enforce the document lifecycle: `draft → in_review → approved / changes_requested → submitted`
- Transition buttons appear dynamically based on the user's project role and the document's current status
- "Request Changes" requires an inline note from the reviewer before proceeding
- Approved documents are locked: Edit button hidden in viewer, redirect in edit page, server action guard
- Every transition is written to the `document_status_history` audit log (append-only)
- Reviewers are notified when a document is submitted for review; document creator notified on approve/changes-requested

## Changes

| File | Change |
|---|---|
| `lib/auth/rbac.ts` | Add `getAvailableTransitions()` — pure helper, safe for client components |
| `lib/actions/workflow.ts` | `transitionDocumentStatus` server action with role check, audit log, notifications |
| `components/document-status-actions.tsx` | New client component rendering context-aware workflow buttons |
| `components/document-viewer-client.tsx` | Add `userRole` prop; render `DocumentStatusActions` in header; hide Edit when approved |
| `app/.../documents/[docId]/page.tsx` | Pass `userRole` to viewer client |
| `app/.../documents/[docId]/edit/page.tsx` | Redirect if `doc.status === "approved"` |
| `lib/actions/documents.ts` | Block `saveDocumentVersion` if document is approved |

## Test plan

- [ ] Architect: Draft document → "Submit for Review" button visible → click transitions to `in_review`
- [ ] Civil engineer: `in_review` document → "Approve" and "Request Changes" buttons visible
- [ ] "Request Changes" → note form appears; submitting without note shows error
- [ ] Approved document: Edit button hidden; navigating to `/edit` redirects to viewer
- [ ] Carpenter: no workflow buttons visible
- [ ] Audit log: `document_status_history` row written for each transition
- [ ] Notifications: civil engineers receive notification when doc submitted for review; architect receives notification on decision

🤖 Generated with [Claude Code](https://claude.com/claude-code)