### PR TITLE
feat: Claude API + Vercel AI SDK integration (#12)

### DIFF
--- a/app/api/ai/chat/route.ts
+++ b/app/api/ai/chat/route.ts
@@ -1,0 +1,91 @@
+import { convertToModelMessages, streamText, UIMessage } from "ai";
+import { createClient } from "@/lib/supabase/server";
+import { getClaudeModel, DEFAULT_MODEL } from "@/lib/ai/claude";
+
+// ---------------------------------------------------------------------------
+// In-process rate limiter — 10 requests per user per minute.
+// NOTE: This is per-instance. In a multi-instance / edge deployment, replace
+// with a distributed store (Upstash Redis, Vercel KV, or Supabase RPC).
+// ---------------------------------------------------------------------------
+const rateMap = new Map<string, { count: number; resetAt: number }>();
+
+function checkRateLimit(userId: string, maxPerMinute = 10): boolean {
+  const now = Date.now();
+  const entry = rateMap.get(userId);
+
+  if (!entry || now > entry.resetAt) {
+    rateMap.set(userId, { count: 1, resetAt: now + 60_000 });
+    return true;
+  }
+
+  if (entry.count >= maxPerMinute) return false;
+  entry.count++;
+  return true;
+}
+
+export async function POST(request: Request) {
+  // ── Auth ──────────────────────────────────────────────────────────────────
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return Response.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  // ── Rate limit ────────────────────────────────────────────────────────────
+  if (!checkRateLimit(user.id)) {
+    return Response.json(
+      { error: "Rate limit exceeded. Please wait before making another request." },
+      { status: 429 },
+    );
+  }
+
+  // ── Parse body ────────────────────────────────────────────────────────────
+  let messages: UIMessage[];
+  let systemPrompt: string | undefined;
+
+  try {
+    const body = (await request.json()) as {
+      messages: UIMessage[];
+      systemPrompt?: string;
+    };
+    messages = body.messages;
+    systemPrompt = body.systemPrompt;
+  } catch {
+    return Response.json({ error: "Invalid request body" }, { status: 400 });
+  }
+
+  if (!Array.isArray(messages) || messages.length === 0) {
+    return Response.json({ error: "messages array is required" }, { status: 400 });
+  }
+
+  // ── Stream ────────────────────────────────────────────────────────────────
+  try {
+    const model = getClaudeModel();
+
+    console.log("AI request:", {
+      userId: user.id,
+      model: DEFAULT_MODEL,
+      messageCount: messages.length,
+    });
+
+    const result = streamText({
+      model,
+      ...(systemPrompt ? { system: systemPrompt } : {}),
+      messages: await convertToModelMessages(messages),
+      maxOutputTokens: 4096,
+    });
+
+    return result.toTextStreamResponse();
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Unknown error";
+    console.error("Claude API error:", { userId: user.id, message });
+
+    return Response.json(
+      { error: "AI service unavailable. Please try again." },
+      { status: 503 },
+    );
+  }
+}

--- a/app/app/(app)/ai-test/page.tsx
+++ b/app/app/(app)/ai-test/page.tsx
@@ -1,0 +1,17 @@
+import { redirect } from "next/navigation";
+import { AiTestPanel } from "@/components/ai-test-panel";
+
+// This page is only accessible in development — it never ships to production.
+export default function AiTestPage() {
+  if (process.env.NODE_ENV === "production") {
+    redirect("/app");
+  }
+
+  return (
+    <div className="max-w-2xl mx-auto py-8 px-4">
+      <h1 className="text-xl font-semibold mb-1">AI Test Panel</h1>
+      <p className="text-sm text-muted-foreground mb-6">Development only — hidden in production.</p>
+      <AiTestPanel />
+    </div>
+  );
+}

--- a/components/ai-test-panel.tsx
+++ b/components/ai-test-panel.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+import { useState } from "react";
+import { useChat } from "@ai-sdk/react";
+import { TextStreamChatTransport } from "ai";
+import type { UIMessage } from "ai";
+import { Send } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { cn } from "@/lib/utils";
+
+function getTextContent(msg: UIMessage): string {
+  return msg.parts
+    .filter((p) => p.type === "text")
+    .map((p) => (p as { type: "text"; text: string }).text)
+    .join("");
+}
+
+export function AiTestPanel() {
+  const [inputValue, setInputValue] = useState("");
+
+  const { messages, sendMessage, status, error } = useChat({
+    transport: new TextStreamChatTransport({ api: "/api/ai/chat" }),
+  });
+
+  const isLoading = status === "submitted" || status === "streaming";
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    const text = inputValue.trim();
+    if (!text || isLoading) return;
+    setInputValue("");
+    await sendMessage({ text });
+  }
+
+  return (
+    <div className="rounded-lg border bg-card flex flex-col gap-0 overflow-hidden">
+      {/* Message list */}
+      <div className="flex-1 overflow-auto p-4 space-y-3 min-h-[320px] max-h-[480px]">
+        {messages.length === 0 && (
+          <p className="text-sm text-muted-foreground text-center mt-16">
+            Send a message to test the Claude API connection.
+          </p>
+        )}
+        {messages.map((m: UIMessage) => (
+          <div
+            key={m.id}
+            className={cn(
+              "rounded-md px-3 py-2 text-sm max-w-[85%]",
+              m.role === "user"
+                ? "bg-[var(--color-brand-navy)] text-white ml-auto"
+                : "bg-muted",
+            )}
+          >
+            <span className="font-medium text-[11px] block mb-0.5 opacity-70">
+              {m.role === "user" ? "You" : "Claude"}
+            </span>
+            <p className="whitespace-pre-wrap">{getTextContent(m)}</p>
+          </div>
+        ))}
+        {isLoading && (
+          <div className="bg-muted rounded-md px-3 py-2 text-sm max-w-[85%] animate-pulse">
+            <span className="font-medium text-[11px] block mb-0.5 opacity-70">Claude</span>
+            <span className="text-muted-foreground">Thinking…</span>
+          </div>
+        )}
+      </div>
+
+      {/* Error */}
+      {error && (
+        <p className="px-4 py-2 text-xs text-destructive border-t">{error.message}</p>
+      )}
+
+      {/* Input */}
+      <form onSubmit={handleSubmit} className="flex items-center gap-2 border-t px-3 py-2.5">
+        <Input
+          value={inputValue}
+          onChange={(e) => setInputValue(e.target.value)}
+          placeholder="Ask Claude something…"
+          disabled={isLoading}
+          className="text-sm"
+        />
+        <Button
+          type="submit"
+          size="sm"
+          disabled={isLoading || !inputValue.trim()}
+          className="shrink-0"
+        >
+          <Send className="h-3.5 w-3.5" />
+        </Button>
+      </form>
+    </div>
+  );
+}

--- a/lib/ai/claude.ts
+++ b/lib/ai/claude.ts
@@ -1,0 +1,31 @@
+import "server-only";
+import { createAnthropic } from "@ai-sdk/anthropic";
+
+/**
+ * Default Claude model used across all AI features.
+ * Pinned here so that model updates are intentional and visible.
+ */
+export const DEFAULT_MODEL = "claude-sonnet-4-6" as const;
+
+/**
+ * Returns a configured Anthropic provider.
+ * Throws at startup if ANTHROPIC_API_KEY is missing — fail fast.
+ */
+function getAnthropicProvider() {
+  const apiKey = process.env.ANTHROPIC_API_KEY;
+  if (!apiKey) {
+    throw new Error("ANTHROPIC_API_KEY environment variable is not set");
+  }
+  return createAnthropic({ apiKey });
+}
+
+/**
+ * Returns a Claude model instance ready for use with Vercel AI SDK functions
+ * (streamText, generateText, generateObject, etc.)
+ *
+ * Usage:
+ *   const result = streamText({ model: getClaudeModel(), messages });
+ */
+export function getClaudeModel(model: string = DEFAULT_MODEL) {
+  return getAnthropicProvider()(model);
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,8 @@
       "name": "bricks",
       "version": "0.1.0",
       "dependencies": {
+        "@ai-sdk/anthropic": "^3.0.54",
+        "@ai-sdk/react": "^3.0.113",
         "@supabase/ssr": "^0.9.0",
         "@supabase/supabase-js": "^2.98.0",
         "@tiptap/extension-image": "^3.20.0",
@@ -18,6 +20,7 @@
         "@tiptap/react": "^3.20.0",
         "@tiptap/starter-kit": "^3.20.0",
         "@types/dompurify": "^3.0.5",
+        "ai": "^6.0.111",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "dompurify": "^3.3.1",
@@ -42,6 +45,86 @@
         "tailwindcss": "^4",
         "tw-animate-css": "^1.4.0",
         "typescript": "^5.9.3"
+      }
+    },
+    "node_modules/@ai-sdk/anthropic": {
+      "version": "3.0.54",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/anthropic/-/anthropic-3.0.54.tgz",
+      "integrity": "sha512-UhSPZ63FsTNO7PQCfxsqJIgkij1sivU3qfXydlSd4ugshpkNhd2v9s78G/40/G5C3pKSRfp/CfaSvivrneQfCg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.8",
+        "@ai-sdk/provider-utils": "4.0.17"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/gateway": {
+      "version": "3.0.63",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-3.0.63.tgz",
+      "integrity": "sha512-0jwdkN3elC4Q9aT2ALxjXtGGVoye15zYgof6GfvuH1a9QKx9Rj4Wi2vy6SyyLvtSA/lB786dTZgC+cGwe6vzmA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.8",
+        "@ai-sdk/provider-utils": "4.0.17",
+        "@vercel/oidc": "3.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/provider": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.8.tgz",
+      "integrity": "sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@ai-sdk/provider-utils": {
+      "version": "4.0.17",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.17.tgz",
+      "integrity": "sha512-oyCeFINTYK0B8ZGUBiQc05G5vytPlKSmTTtm19xfJuUgoi8zkvvRcoPQci4mSnyfpPn2XSFFDfsALG8uGcapfg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.8",
+        "@standard-schema/spec": "^1.1.0",
+        "eventsource-parser": "^3.0.6"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/react": {
+      "version": "3.0.113",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/react/-/react-3.0.113.tgz",
+      "integrity": "sha512-Ey/AZIEjUAaxWKr2wzoZsRx+BocKUKTNSGPe+fv1cGwFQCK0vvhW7lYyOMg0HBsnzH573T4QMzHCA+FvYoxumA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider-utils": "4.0.17",
+        "ai": "6.0.111",
+        "swr": "^2.2.5",
+        "throttleit": "2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^18 || ~19.0.1 || ~19.1.2 || ^19.2.1"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -1963,6 +2046,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
+      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/@radix-ui/number": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@radix-ui/number/-/number-1.1.1.tgz",
@@ -3498,6 +3590,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
       "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "license": "MIT"
     },
     "node_modules/@supabase/auth-js": {
@@ -5161,6 +5259,15 @@
         "win32"
       ]
     },
+    "node_modules/@vercel/oidc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.1.0.tgz",
+      "integrity": "sha512-Fw28YZpRnA3cAHHDlkt7xQHiJ0fcL+NRcIqsocZQUSmbzeIKRpwttJjik5ZGanXP+vlA4SbTg+AbA3bP363l+w==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 20"
+      }
+    },
     "node_modules/accepts": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
@@ -5206,6 +5313,24 @@
       "license": "MIT",
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/ai": {
+      "version": "6.0.111",
+      "resolved": "https://registry.npmjs.org/ai/-/ai-6.0.111.tgz",
+      "integrity": "sha512-K5aikNm4JGfJkzwIr3yA/qhOYIOIvOqjCxSQjQQ7bWWqm0uuPO2/qgdXL23gYJdTLPPYfvi2TTS+bg2Yp+r2Lw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/gateway": "3.0.63",
+        "@ai-sdk/provider": "3.0.8",
+        "@ai-sdk/provider-utils": "4.0.17",
+        "@opentelemetry/api": "1.9.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
       }
     },
     "node_modules/ajv": {
@@ -6319,6 +6444,15 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -7167,7 +7301,6 @@
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
       "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
@@ -8790,6 +8923,12 @@
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/json-schema": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
+      "license": "(AFL-2.1 OR BSD-3-Clause)"
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
@@ -11956,6 +12095,19 @@
         "uuid": "^10.0.0"
       }
     },
+    "node_modules/swr": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/swr/-/swr-2.4.1.tgz",
+      "integrity": "sha512-2CC6CiKQtEwaEeNiqWTAw9PGykW8SR5zZX8MZk6TeAvEAnVS7Visz8WzphqgtQ8v2xz/4Q5K+j+SeMaKXeeQIA==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.3",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "peerDependencies": {
+        "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/tagged-tag": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/tagged-tag/-/tagged-tag-1.0.0.tgz",
@@ -11998,6 +12150,18 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/throttleit": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-2.1.0.tgz",
+      "integrity": "sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/tiny-invariant": {
@@ -12959,7 +13123,6 @@
       "version": "4.3.6",
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
     "format:check": "prettier --check ."
   },
   "dependencies": {
+    "@ai-sdk/anthropic": "^3.0.54",
+    "@ai-sdk/react": "^3.0.113",
     "@supabase/ssr": "^0.9.0",
     "@supabase/supabase-js": "^2.98.0",
     "@tiptap/extension-image": "^3.20.0",
@@ -22,6 +24,7 @@
     "@tiptap/react": "^3.20.0",
     "@tiptap/starter-kit": "^3.20.0",
     "@types/dompurify": "^3.0.5",
+    "ai": "^6.0.111",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "dompurify": "^3.3.1",


### PR DESCRIPTION
## Summary

- Installs `ai@6`, `@ai-sdk/anthropic`, and `@ai-sdk/react`
- `lib/ai/claude.ts` — `getClaudeModel()` server-only helper; model pinned to `claude-sonnet-4-6`
- `POST /api/ai/chat` — authenticated + rate-limited (10 req/min per user, in-process; comment notes production needs distributed KV); converts SDK v6 `UIMessage[]` via `convertToModelMessages`, returns `toTextStreamResponse()`
- Dev-only test panel at `/app/ai-test` using `useChat` + `TextStreamChatTransport`; renders streaming tokens progressively; redirects to `/app` in production

## Security

- `ANTHROPIC_API_KEY` used only in `lib/ai/claude.ts` (marked `import "server-only"`)
- Route requires authenticated Supabase session before invoking Claude
- Rate limiting prevents cost abuse from a single user

## Notes on AI SDK v6 changes

AI SDK v6 (released ~2025) has significant breaking changes from v4/v5:
- `useChat` moved to `@ai-sdk/react`; uses `TextStreamChatTransport` instead of `api` string
- `Message` → `UIMessage` (parts-based structure); converted with async `convertToModelMessages()`
- `maxTokens` → `maxOutputTokens`; `toDataStreamResponse()` → `toTextStreamResponse()`

## Test plan

- [ ] `POST /api/ai/chat` without auth → 401
- [ ] `POST /api/ai/chat` with valid session and `{ messages: [...] }` → streaming text response
- [ ] Navigate to `/app/ai-test` in dev → chat panel loads and streams Claude response
- [ ] Navigate to `/app/ai-test` in production build → redirects to `/app`
- [ ] Send 11 requests rapidly → 11th returns 429
- [ ] Confirm `ANTHROPIC_API_KEY` is absent from `npm run build` client bundle

🤖 Generated with [Claude Code](https://claude.com/claude-code)