### PR TITLE
feat: Notifications system — in-app Realtime + email (#19)

### DIFF
--- a/app/[locale]/app/layout.tsx
+++ b/app/[locale]/app/layout.tsx
@@ -5,6 +5,7 @@ import { signOut } from "@/lib/actions/auth";
 import { Logo } from "@/components/logo";
 import { Button } from "@/components/ui/button";
 import { LanguageSwitcher } from "@/components/language-switcher";
+import { NotificationBell } from "@/components/notification-bell";
 import { Link } from "@/lib/navigation";
 
 export default async function AppLayout({
@@ -41,10 +42,17 @@ export default async function AppLayout({
               >
                 {t("projects")}
               </Link>
+              <Link
+                href="/app/settings"
+                className="text-sm font-medium text-muted-foreground hover:text-foreground px-3 py-1.5 rounded-md transition-colors"
+              >
+                Settings
+              </Link>
             </nav>
           </div>
 
           <div className="flex items-center gap-2">
+            <NotificationBell userId={user.id} />
             <LanguageSwitcher />
             <span className="hidden sm:block text-sm text-muted-foreground">
               {displayName}

--- a/app/[locale]/app/settings/page.tsx
+++ b/app/[locale]/app/settings/page.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import { useEffect, useState, useTransition } from "react";
+import { createClient } from "@/lib/supabase/client";
+import { updateEmailPrefs } from "@/lib/actions/notifications";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+
+const PREF_LABELS: Record<string, string> = {
+  status_change: "Document status changes (submitted for review, approved, changes requested)",
+  mention: "@mentions in comments",
+  comment_reply: "New comments on your documents",
+  compliance_complete: "Compliance check completed",
+};
+
+type Prefs = Record<string, boolean>;
+
+const DEFAULT_PREFS: Prefs = {
+  status_change: true,
+  mention: true,
+  comment_reply: true,
+  compliance_complete: true,
+};
+
+export default function SettingsPage() {
+  const [prefs, setPrefs] = useState<Prefs>(DEFAULT_PREFS);
+  const [loading, setLoading] = useState(true);
+  const [saved, setSaved] = useState(false);
+  const [isPending, startTransition] = useTransition();
+
+  useEffect(() => {
+    async function load() {
+      const supabase = createClient();
+      const {
+        data: { user },
+      } = await supabase.auth.getUser();
+      if (!user) return;
+      const { data } = await supabase
+        .from("profiles")
+        .select("email_prefs")
+        .eq("id", user.id)
+        .single();
+      if (data?.email_prefs) {
+        setPrefs({ ...DEFAULT_PREFS, ...(data.email_prefs as Prefs) });
+      }
+      setLoading(false);
+    }
+    load();
+  }, []);
+
+  function toggle(key: string) {
+    setPrefs((prev) => ({ ...prev, [key]: !prev[key] }));
+    setSaved(false);
+  }
+
+  function handleSave() {
+    startTransition(async () => {
+      await updateEmailPrefs(prefs);
+      setSaved(true);
+    });
+  }
+
+  return (
+    <div className="max-w-lg space-y-6">
+      <div>
+        <h1 className="text-2xl font-semibold">Settings</h1>
+        <p className="text-sm text-muted-foreground mt-0.5">Notification preferences</p>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Email notifications</CardTitle>
+          <CardDescription>
+            In-app notifications are always delivered. Disable email for specific types below.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          {loading ? (
+            <p className="text-sm text-muted-foreground">Loading…</p>
+          ) : (
+            Object.keys(PREF_LABELS).map((key) => (
+              <label key={key} className="flex items-start gap-3 cursor-pointer">
+                <input
+                  type="checkbox"
+                  className="mt-0.5 h-4 w-4 accent-foreground"
+                  checked={prefs[key] ?? true}
+                  onChange={() => toggle(key)}
+                />
+                <span className="text-sm">{PREF_LABELS[key]}</span>
+              </label>
+            ))
+          )}
+
+          <div className="pt-2 flex items-center gap-3">
+            <Button size="sm" disabled={isPending || loading} onClick={handleSave}>
+              {isPending ? "Saving…" : "Save"}
+            </Button>
+            {saved && <span className="text-sm text-green-600">Saved.</span>}
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/app/api/notifications/route.ts
+++ b/app/api/notifications/route.ts
@@ -1,0 +1,25 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const limit = Math.min(parseInt(request.nextUrl.searchParams.get("limit") ?? "20"), 50);
+
+  const { data, error } = await supabase
+    .from("notifications")
+    .select("id, type, title, body, link, read_at, created_at")
+    .eq("user_id", user.id)
+    .order("created_at", { ascending: false })
+    .limit(limit);
+
+  if (error) return NextResponse.json({ error: "Could not fetch notifications" }, { status: 500 });
+
+  const unreadCount = (data ?? []).filter((n) => !n.read_at).length;
+
+  return NextResponse.json({ notifications: data ?? [], unreadCount });
+}

--- a/components/notification-bell.tsx
+++ b/components/notification-bell.tsx
@@ -1,0 +1,189 @@
+"use client";
+
+import { useEffect, useReducer, useTransition } from "react";
+import { Bell } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { createClient } from "@/lib/supabase/client";
+import { markNotificationRead, markAllNotificationsRead } from "@/lib/actions/notifications";
+import { useRouter } from "@/lib/navigation";
+
+interface Notification {
+  id: string;
+  type: string;
+  title: string;
+  body: string | null;
+  link: string | null;
+  read_at: string | null;
+  created_at: string;
+}
+
+interface State {
+  notifications: Notification[];
+  loading: boolean;
+}
+
+type Action =
+  | { type: "LOADED"; payload: Notification[] }
+  | { type: "PREPEND"; payload: Notification }
+  | { type: "MARK_READ"; id: string }
+  | { type: "MARK_ALL_READ" };
+
+function reducer(state: State, action: Action): State {
+  switch (action.type) {
+    case "LOADED":
+      return { notifications: action.payload, loading: false };
+    case "PREPEND":
+      return {
+        ...state,
+        notifications: [action.payload, ...state.notifications].slice(0, 20),
+      };
+    case "MARK_READ":
+      return {
+        ...state,
+        notifications: state.notifications.map((n) =>
+          n.id === action.id ? { ...n, read_at: new Date().toISOString() } : n,
+        ),
+      };
+    case "MARK_ALL_READ":
+      return {
+        ...state,
+        notifications: state.notifications.map((n) => ({
+          ...n,
+          read_at: n.read_at ?? new Date().toISOString(),
+        })),
+      };
+    default:
+      return state;
+  }
+}
+
+export function NotificationBell({ userId }: { userId: string }) {
+  const [state, dispatch] = useReducer(reducer, { notifications: [], loading: true });
+  const [isPending, startTransition] = useTransition();
+  const router = useRouter();
+
+  const unreadCount = state.notifications.filter((n) => !n.read_at).length;
+
+  useEffect(() => {
+    async function load() {
+      const res = await fetch("/api/notifications?limit=20");
+      if (res.ok) {
+        const data = await res.json();
+        dispatch({ type: "LOADED", payload: data.notifications });
+      }
+    }
+    load();
+
+    // Subscribe to realtime inserts
+    const supabase = createClient();
+    const channel = supabase
+      .channel(`notifications:${userId}`)
+      .on(
+        "postgres_changes",
+        {
+          event: "INSERT",
+          schema: "public",
+          table: "notifications",
+          filter: `user_id=eq.${userId}`,
+        },
+        (payload) => {
+          dispatch({ type: "PREPEND", payload: payload.new as Notification });
+        },
+      )
+      .subscribe();
+
+    return () => {
+      supabase.removeChannel(channel);
+    };
+  }, [userId]);
+
+  function handleClick(notification: Notification) {
+    if (!notification.read_at) {
+      dispatch({ type: "MARK_READ", id: notification.id });
+      startTransition(async () => {
+        await markNotificationRead(notification.id);
+      });
+    }
+    if (notification.link) {
+      router.push(notification.link);
+    }
+  }
+
+  function handleMarkAll() {
+    dispatch({ type: "MARK_ALL_READ" });
+    startTransition(async () => {
+      await markAllNotificationsRead();
+    });
+  }
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button variant="ghost" size="icon" className="relative h-8 w-8">
+          <Bell className="h-4 w-4" />
+          {unreadCount > 0 && (
+            <span className="absolute -top-0.5 -right-0.5 flex h-4 w-4 items-center justify-center rounded-full bg-destructive text-[10px] font-medium text-destructive-foreground">
+              {unreadCount > 9 ? "9+" : unreadCount}
+            </span>
+          )}
+        </Button>
+      </DropdownMenuTrigger>
+
+      <DropdownMenuContent align="end" className="w-80">
+        <div className="flex items-center justify-between px-3 py-2">
+          <span className="text-sm font-semibold">Notifications</span>
+          {unreadCount > 0 && (
+            <button
+              className="text-xs text-muted-foreground hover:text-foreground"
+              disabled={isPending}
+              onClick={handleMarkAll}
+            >
+              Mark all read
+            </button>
+          )}
+        </div>
+        <DropdownMenuSeparator />
+
+        {state.loading ? (
+          <div className="px-3 py-4 text-center text-sm text-muted-foreground">Loading…</div>
+        ) : state.notifications.length === 0 ? (
+          <div className="px-3 py-4 text-center text-sm text-muted-foreground">
+            No notifications yet.
+          </div>
+        ) : (
+          state.notifications.slice(0, 10).map((n) => (
+            <DropdownMenuItem
+              key={n.id}
+              className="flex flex-col items-start gap-0.5 px-3 py-2.5 cursor-pointer"
+              onClick={() => handleClick(n)}
+            >
+              <div className="flex w-full items-start gap-2">
+                {!n.read_at && (
+                  <span className="mt-1.5 h-2 w-2 shrink-0 rounded-full bg-blue-500" />
+                )}
+                <div className="flex-1 min-w-0">
+                  <p className={`text-sm leading-snug ${n.read_at ? "text-muted-foreground" : "font-medium"}`}>
+                    {n.title}
+                  </p>
+                  {n.body && (
+                    <p className="text-xs text-muted-foreground truncate mt-0.5">{n.body}</p>
+                  )}
+                </div>
+              </div>
+              <span className="text-[11px] text-muted-foreground self-end">
+                {new Date(n.created_at).toLocaleString()}
+              </span>
+            </DropdownMenuItem>
+          ))
+        )}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/lib/actions/comments.ts
+++ b/lib/actions/comments.ts
@@ -4,6 +4,7 @@ import { revalidatePath } from "next/cache";
 import { createClient } from "@/lib/supabase/server";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { getUserProjectRole } from "@/lib/auth/rbac";
+import { notify, notifyMany } from "@/lib/notifications/notify";
 
 /** Strip HTML tags and trim whitespace — comments are stored as plain text. */
 function sanitizeBody(input: string): string {
@@ -47,46 +48,58 @@ export async function postComment(
 
   if (error || !comment) return { error: "Could not save comment" };
 
+  // Fetch author name + doc owner once for all notifications below
+  const [authorResult, docResult] = await Promise.all([
+    admin.from("profiles").select("full_name").eq("id", user.id).single(),
+    admin.from("documents").select("created_by").eq("id", docId).single(),
+  ]);
+  const authorName = authorResult.data?.full_name ?? "Someone";
+  const docOwnerId = docResult.data?.created_by ?? null;
+
   // ── @mention detection ──────────────────────────────────────────────────
   // Match @Word patterns (single token) against project members' first names.
   const mentionTokens = Array.from(clean.matchAll(/@(\w+)/g)).map((m) =>
     m[1].toLowerCase(),
   );
 
+  let mentionedIds: string[] = [];
   if (mentionTokens.length > 0) {
     const { data: members } = await admin
       .from("project_members")
       .select("user_id, profiles(full_name)")
       .eq("project_id", projectId);
 
-    const authorProfile = await admin
-      .from("profiles")
-      .select("full_name")
-      .eq("id", user.id)
-      .single();
-
-    const authorName = authorProfile.data?.full_name ?? "Someone";
-
-    const mentionedIds = (members ?? [])
+    mentionedIds = (members ?? [])
       .filter((m) => {
         const profileData = Array.isArray(m.profiles) ? m.profiles[0] : m.profiles;
         const firstName = (profileData?.full_name ?? "").split(" ")[0].toLowerCase();
         return mentionTokens.includes(firstName);
       })
       .map((m) => m.user_id)
-      .filter((id) => id !== user.id); // Don't notify yourself
+      .filter((id) => id !== user.id);
 
     if (mentionedIds.length > 0) {
-      await admin.from("notifications").insert(
+      await notifyMany(
         mentionedIds.map((userId) => ({
-          user_id: userId,
-          type: "mention",
+          userId,
+          type: "mention" as const,
           title: `${authorName} mentioned you in a comment`,
           body: clean.slice(0, 200),
           link: `/app/projects/${projectId}/documents/${docId}`,
         })),
       );
     }
+  }
+
+  // ── Notify doc owner of new comment (skip if they authored it or were already mentioned) ──
+  if (docOwnerId && docOwnerId !== user.id && !mentionedIds.includes(docOwnerId)) {
+    await notify({
+      userId: docOwnerId,
+      type: "comment_reply",
+      title: `New comment on your document`,
+      body: `${authorName}: ${clean.slice(0, 100)}`,
+      link: `/app/projects/${projectId}/documents/${docId}`,
+    });
   }
 
   revalidatePath(`/app/projects/${projectId}/documents/${docId}`);

--- a/lib/actions/notifications.ts
+++ b/lib/actions/notifications.ts
@@ -1,0 +1,66 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { createClient } from "@/lib/supabase/server";
+import { createAdminClient } from "@/lib/supabase/admin";
+
+export async function markNotificationRead(notificationId: string): Promise<{ error?: string }> {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return { error: "Unauthorized" };
+
+  const { error } = await supabase
+    .from("notifications")
+    .update({ read_at: new Date().toISOString() })
+    .eq("id", notificationId)
+    .eq("user_id", user.id)
+    .is("read_at", null);
+
+  if (error) return { error: "Could not mark notification as read" };
+  return {};
+}
+
+export async function markAllNotificationsRead(): Promise<{ error?: string }> {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return { error: "Unauthorized" };
+
+  const { error } = await supabase
+    .from("notifications")
+    .update({ read_at: new Date().toISOString() })
+    .eq("user_id", user.id)
+    .is("read_at", null);
+
+  if (error) return { error: "Could not mark notifications as read" };
+  return {};
+}
+
+export async function updateEmailPrefs(
+  prefs: Record<string, boolean>,
+): Promise<{ error?: string }> {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return { error: "Unauthorized" };
+
+  // Validate keys against allowed types
+  const allowed = new Set(["status_change", "mention", "comment_reply", "compliance_complete"]);
+  const sanitised = Object.fromEntries(
+    Object.entries(prefs).filter(([k]) => allowed.has(k)),
+  );
+
+  const admin = createAdminClient();
+  const { error } = await (admin as any)
+    .from("profiles")
+    .update({ email_prefs: sanitised, updated_at: new Date().toISOString() })
+    .eq("id", user.id);
+
+  if (error) return { error: "Could not save preferences" };
+  revalidatePath("/app/settings");
+  return {};
+}

--- a/lib/actions/workflow.ts
+++ b/lib/actions/workflow.ts
@@ -11,6 +11,7 @@ import {
 import type { SupabaseClient } from "@supabase/supabase-js";
 import type { Database } from "@/types/database";
 import { fireOutboundWebhooks } from "@/lib/webhooks/outbound";
+import { notifyMany } from "@/lib/notifications/notify";
 
 const STATUS_LABELS: Record<DocumentStatus, string> = {
   draft: "Draft",
@@ -169,11 +170,10 @@ async function sendWorkflowNotifications({
       .filter((id) => id !== actorId);
 
     if (recipientIds.length > 0) {
-      const notifClient = admin as any;
-      await notifClient.from("notifications").insert(
+      await notifyMany(
         recipientIds.map((userId: string) => ({
-          user_id: userId,
-          type: "status_change",
+          userId,
+          type: "status_change" as const,
           title: `"${docTitle}" is ready for review`,
           body: `${actorName} submitted the document for review.`,
           link,
@@ -198,10 +198,9 @@ async function sendWorkflowNotifications({
         ? `${actorName} approved the document.`
         : `${actorName} requested changes${note?.trim() ? `: ${note.trim().slice(0, 200)}` : "."}`;
 
-    const notifClient = admin as any;
-    await notifClient.from("notifications").insert([
+    await notifyMany([
       {
-        user_id: documentCreatedBy,
+        userId: documentCreatedBy,
         type: "status_change",
         title,
         body,

--- a/lib/ai/compliance.ts
+++ b/lib/ai/compliance.ts
@@ -5,6 +5,7 @@ import { PDFParse } from "pdf-parse";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { matchDocuments } from "@/lib/ai/rag";
 import { getClaudeModel, DEFAULT_MODEL } from "@/lib/ai/claude";
+import { notify } from "@/lib/notifications/notify";
 import type { Json } from "@/types/database";
 
 // ---------------------------------------------------------------------------
@@ -81,7 +82,7 @@ export async function runComplianceCheck(
   const { data: check } = await admin
     .from("compliance_checks")
     .select(
-      "id, document_version_id, document_versions(content_type, rich_text_json, storage_path, mime_type, documents(project_id))",
+      "id, document_version_id, document_versions(content_type, rich_text_json, storage_path, mime_type, documents(project_id, id, title, created_by))",
     )
     .eq("id", checkId)
     .single();
@@ -101,7 +102,7 @@ export async function runComplianceCheck(
     rich_text_json: Json | null;
     storage_path: string | null;
     mime_type: string | null;
-    documents: { project_id: string } | null;
+    documents: { project_id: string; id: string; title: string; created_by: string } | null;
   } | null;
 
   if (!version) {
@@ -206,6 +207,26 @@ export async function runComplianceCheck(
       issueCount: object.issues.length,
       durationMs: duration,
     });
+
+    // Notify document uploader
+    const docOwner = version.documents?.created_by;
+    const docTitle = version.documents?.title ?? "your document";
+    const docId = version.documents?.id;
+    const projectId = version.documents?.project_id;
+    if (docOwner && docId && projectId) {
+      void notify({
+        userId: docOwner,
+        type: "compliance_complete",
+        title: `Compliance check complete for "${docTitle}"`,
+        body:
+          object.issues.length === 0
+            ? "No compliance issues found."
+            : `${object.issues.length} issue${object.issues.length === 1 ? "" : "s"} found.`,
+        link: `/app/projects/${projectId}/documents/${docId}`,
+      }).catch((err) => {
+        console.error("Compliance notification error:", err);
+      });
+    }
   } catch (err) {
     const duration = Date.now() - startTime;
     console.error("Compliance check Claude error:", checkId, err);

--- a/lib/notifications/email.ts
+++ b/lib/notifications/email.ts
@@ -1,0 +1,99 @@
+import "server-only";
+import { Resend } from "resend";
+import { createAdminClient } from "@/lib/supabase/admin";
+
+let resend: Resend | null = null;
+
+function getResend(): Resend {
+  if (!resend) {
+    const key = process.env.RESEND_API_KEY;
+    if (!key) throw new Error("RESEND_API_KEY is not set");
+    resend = new Resend(key);
+  }
+  return resend;
+}
+
+const FROM_ADDRESS = process.env.EMAIL_FROM ?? "Bricks <notifications@bricks.app>";
+
+export type NotificationType =
+  | "status_change"
+  | "mention"
+  | "comment_reply"
+  | "compliance_complete";
+
+interface EmailPayload {
+  userId: string;
+  type: NotificationType;
+  title: string;
+  body: string | null;
+  link: string | null;
+}
+
+/**
+ * Sends a notification email to a user if they have not opted out of that type.
+ * Fails silently — in-app notification is the source of truth.
+ */
+export async function sendNotificationEmail(payload: EmailPayload): Promise<void> {
+  const apiKey = process.env.RESEND_API_KEY;
+  if (!apiKey) return; // Email not configured — skip silently
+
+  const admin = createAdminClient();
+
+  // Fetch user email + preferences in one query
+  const { data: profile } = await (admin as any)
+    .from("profiles")
+    .select("email_prefs, auth_users:id(email)")
+    .eq("id", payload.userId)
+    .single();
+
+  // Check opt-out preference
+  const prefs: Record<string, boolean> = profile?.email_prefs ?? {};
+  if (prefs[payload.type] === false) return;
+
+  // Get user email from auth.users via admin API
+  const {
+    data: { user },
+  } = await admin.auth.admin.getUserById(payload.userId);
+  const email = user?.email;
+  if (!email) return;
+
+  const appUrl = process.env.NEXT_PUBLIC_APP_URL ?? "https://bricks.app";
+  const linkUrl = payload.link ? `${appUrl}${payload.link}` : appUrl;
+
+  const html = `
+<!DOCTYPE html>
+<html>
+<body style="font-family:sans-serif;max-width:520px;margin:0 auto;padding:24px;color:#111">
+  <p style="font-size:1.1em;font-weight:600;margin-bottom:8px">${escapeHtml(payload.title)}</p>
+  ${payload.body ? `<p style="color:#555;margin-bottom:16px">${escapeHtml(payload.body)}</p>` : ""}
+  <a href="${linkUrl}" style="display:inline-block;background:#0f172a;color:#fff;padding:10px 20px;border-radius:6px;text-decoration:none;font-size:0.9em">
+    View in Bricks
+  </a>
+  <p style="color:#999;font-size:0.8em;margin-top:24px">
+    You can manage your email notification preferences in your profile settings.
+  </p>
+</body>
+</html>`;
+
+  try {
+    const { error } = await getResend().emails.send({
+      from: FROM_ADDRESS,
+      to: email,
+      subject: payload.title,
+      html,
+    });
+    if (error) {
+      console.error("Email send failed:", { userId: payload.userId, type: payload.type }, error);
+    }
+  } catch (err) {
+    console.error("Email send error:", { userId: payload.userId, type: payload.type }, err);
+  }
+}
+
+function escapeHtml(str: string): string {
+  return str
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}

--- a/lib/notifications/notify.ts
+++ b/lib/notifications/notify.ts
@@ -1,0 +1,82 @@
+import "server-only";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { sendNotificationEmail, type NotificationType } from "./email";
+
+interface NotifyInput {
+  userId: string;
+  type: NotificationType;
+  title: string;
+  body?: string | null;
+  link?: string | null;
+}
+
+/**
+ * Creates an in-app notification row and fires an email asynchronously.
+ * Always resolves — email failure never blocks the caller.
+ */
+export async function notify(input: NotifyInput): Promise<void> {
+  const admin = createAdminClient();
+
+  const { error } = await admin.from("notifications").insert({
+    user_id: input.userId,
+    type: input.type,
+    title: input.title,
+    body: input.body ?? null,
+    link: input.link ?? null,
+  });
+
+  if (error) {
+    console.error("Failed to insert notification:", error);
+    return;
+  }
+
+  // Non-blocking email
+  void sendNotificationEmail({
+    userId: input.userId,
+    type: input.type,
+    title: input.title,
+    body: input.body ?? null,
+    link: input.link ?? null,
+  }).catch((err) => {
+    console.error("Notification email error:", err);
+  });
+}
+
+/**
+ * Notifies multiple users at once. All rows are inserted in a single call;
+ * emails are fired concurrently but non-blocking.
+ */
+export async function notifyMany(inputs: NotifyInput[]): Promise<void> {
+  if (inputs.length === 0) return;
+
+  const admin = createAdminClient();
+
+  const { error } = await admin.from("notifications").insert(
+    inputs.map((n) => ({
+      user_id: n.userId,
+      type: n.type,
+      title: n.title,
+      body: n.body ?? null,
+      link: n.link ?? null,
+    })),
+  );
+
+  if (error) {
+    console.error("Failed to insert notifications:", error);
+    return;
+  }
+
+  void Promise.allSettled(
+    inputs.map((n) =>
+      sendNotificationEmail({
+        userId: n.userId,
+        type: n.type,
+        title: n.title,
+        body: n.body ?? null,
+        link: n.link ?? null,
+      }),
+    ),
+  ).catch((err) => {
+    console.error("Batch notification email error:", err);
+  });
+}

--- a/supabase/migrations/20260304000500_notification_prefs.sql
+++ b/supabase/migrations/20260304000500_notification_prefs.sql
@@ -1,0 +1,17 @@
+-- ---------------------------------------------------------------------------
+-- Extend notification types to include compliance_complete
+-- ---------------------------------------------------------------------------
+alter table public.notifications
+  drop constraint if exists notifications_type_check;
+
+alter table public.notifications
+  add constraint notifications_type_check
+  check (type in ('mention', 'comment_reply', 'status_change', 'compliance_complete'));
+
+-- ---------------------------------------------------------------------------
+-- Email notification preferences per user (stored as JSONB on profiles)
+-- Each key maps to a notification type; true = send email, false = suppress.
+-- ---------------------------------------------------------------------------
+alter table public.profiles
+  add column if not exists email_prefs jsonb not null default
+    '{"status_change":true,"mention":true,"comment_reply":true,"compliance_complete":true}'::jsonb;

--- a/types/database.ts
+++ b/types/database.ts
@@ -504,6 +504,7 @@ export type Database = {
         Row: {
           avatar_url: string | null
           created_at: string
+          email_prefs: Json
           full_name: string | null
           id: string
           is_admin: boolean
@@ -513,6 +514,7 @@ export type Database = {
         Insert: {
           avatar_url?: string | null
           created_at?: string
+          email_prefs?: Json
           full_name?: string | null
           id: string
           is_admin?: boolean
@@ -522,6 +524,7 @@ export type Database = {
         Update: {
           avatar_url?: string | null
           created_at?: string
+          email_prefs?: Json
           full_name?: string | null
           id?: string
           is_admin?: boolean


### PR DESCRIPTION
## Summary

- Notification bell in app header with live unread count via Supabase Realtime (no page refresh needed)
- Email delivery via Resend with per-type opt-out stored in `profiles.email_prefs`
- Centralised `notify` / `notifyMany` helpers used by all trigger points
- New `/app/settings` page for managing email notification preferences

## Triggers wired

| Event | Recipients | Type |
|---|---|---|
| Document submitted for review | All project civil_engineers + admins | `status_change` |
| Document approved / changes requested | Document owner | `status_change` |
| New comment on document | Document owner | `comment_reply` |
| @mention in comment | Mentioned members | `mention` |
| Compliance check complete | Document uploader | `compliance_complete` |

## Schema

New migration `20260304000500_notification_prefs.sql`:
- Extends `notifications.type` check constraint with `compliance_complete`
- Adds `email_prefs jsonb` column to `profiles` (default: all types enabled)

## Test plan

- [ ] Apply migration: `supabase db push`
- [ ] Set `RESEND_API_KEY` + `EMAIL_FROM` + `NEXT_PUBLIC_APP_URL` in `.env.local`
- [ ] Transition a document → bell updates in real time for reviewer
- [ ] Post a comment → document owner receives in-app notification
- [ ] Disable "status_change" email in Settings → no email sent on next transition
- [ ] Unset `RESEND_API_KEY` → app still works, email step skipped silently

🤖 Generated with [Claude Code](https://claude.com/claude-code)