### PR TITLE
Fix: skip Resend in dev for project member invites (#66)

### DIFF
--- a/lib/actions/projects.ts
+++ b/lib/actions/projects.ts
@@ -205,8 +205,9 @@ export async function inviteMember(
       role,
       token: invite.token,
     });
-  } catch {
+  } catch (err) {
     // Clean up the invite if email fails
+    console.error("inviteMember: email send failed:", err);
     await admin.from("project_invites").delete().eq("token", invite.token);
     return {
       error: "Could not send invite email. Please check the address and try again.",

--- a/lib/email/resend.ts
+++ b/lib/email/resend.ts
@@ -7,6 +7,8 @@ const APP_URL =
 
 const FROM = "Bricks <noreply@bricks.build>";
 
+const IS_DEV = process.env.NODE_ENV === "development";
+
 export async function sendProjectInviteEmail({
   to,
   inviterName,
@@ -22,6 +24,16 @@ export async function sendProjectInviteEmail({
 }) {
   const joinUrl = `${APP_URL}/app/projects/join?token=${token}`;
   const roleLabel = role.replace(/_/g, " ");
+
+  // In local development Resend's domain verification is not available, so
+  // we skip the actual send and print the join URL to the server console.
+  if (IS_DEV) {
+    console.log(
+      "[DEV] Invite email skipped — open this URL to accept the invitation:",
+      joinUrl,
+    );
+    return;
+  }
 
   const { error } = await resend.emails.send({
     from: FROM,
@@ -58,6 +70,7 @@ export async function sendProjectInviteEmail({
   });
 
   if (error) {
+    console.error("Resend email error:", { to }, error.message);
     throw new Error(`Failed to send invite email: ${error.message}`);
   }
 }


### PR DESCRIPTION
## Summary

- In `NODE_ENV=development`, skip the Resend API call and log the invite join URL to the server console instead
- Adds error logging in `inviteMember` so real send failures are visible in production logs

## Root cause

The sender domain `bricks.build` is not verified in Resend for local dev, causing the API to reject every send, which deleted the invite token and returned a generic error to the user.

## Test plan

- [ ] Invite a member from a project in local dev — invite should succeed
- [ ] Check server console for the `[DEV] Invite email skipped` log line with the join URL
- [ ] Navigate to the printed URL and confirm the join flow works

Closes #66

🤖 Generated with [Claude Code](https://claude.com/claude-code)