### PR TITLE
Fix: set immediatelyRender=false on useEditor to prevent SSR mismatch (#68)

### DIFF
--- a/components/document-generator.tsx
+++ b/components/document-generator.tsx
@@ -106,6 +106,7 @@ export function DocumentGenerator({
 
   const editor = useEditor({
     extensions: [StarterKit],
+    immediatelyRender: false,
     editorProps: {
       attributes: {
         class: "tiptap-content focus:outline-none p-6 min-h-[400px] text-sm",

--- a/components/rich-text-editor.tsx
+++ b/components/rich-text-editor.tsx
@@ -112,6 +112,7 @@ export function RichTextEditor({
       TableHeader,
       TableCell,
     ],
+    immediatelyRender: false,
     content: (initialContent as object) ?? "",
     editorProps: {
       attributes: {


### PR DESCRIPTION
## Summary

- Adds `immediatelyRender: false` to `useEditor` in `document-generator.tsx` and `rich-text-editor.tsx`
- Fixes the crash on the document generation page and prevents the same issue on the document edit page

## Root cause

Tiptap v3 throws a hydration error when `useEditor` is used in an SSR-rendered component without `immediatelyRender: false`. Next.js SSR-renders client components to HTML; Tiptap detects this and errors unless the flag is set.

## Test plan

- [ ] Navigate to a project → "Generate document" — no Tiptap SSR error
- [ ] Navigate to a document → "Edit" — no Tiptap SSR error
- [ ] Document generation streams and saves correctly

Closes #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)