### PR TITLE
Fix: detect empty Claude stream to prevent blank document saves (#70)

### DIFF
--- a/app/api/ai/generate/route.ts
+++ b/app/api/ai/generate/route.ts
@@ -115,13 +115,6 @@ export async function POST(request: Request) {
     .filter(Boolean)
     .join("\n");
 
-  const result = streamText({
-    model: getClaudeModel(DEFAULT_MODEL),
-    system: systemPrompt,
-    prompt: userPrompt,
-    maxOutputTokens: 4096,
-  });
-
   console.log("Document generation started:", {
     userId: user.id,
     projectId,
@@ -129,6 +122,22 @@ export async function POST(request: Request) {
     municipality: safeMunicipality,
     language: lang,
   });
+
+  let result;
+  try {
+    result = streamText({
+      model: getClaudeModel(DEFAULT_MODEL),
+      system: systemPrompt,
+      prompt: userPrompt,
+      maxOutputTokens: 4096,
+      onError: ({ error }) => {
+        console.error("Document generation stream error:", error);
+      },
+    });
+  } catch (err) {
+    console.error("Document generation failed to start:", err);
+    return new Response("Generation failed. Please try again.", { status: 500 });
+  }
 
   return result.toTextStreamResponse();
 }

--- a/components/document-generator.tsx
+++ b/components/document-generator.tsx
@@ -177,6 +177,13 @@ export function DocumentGenerator({
         updateEditor(accumulatedRef.current);
       }
 
+      // Guard against empty response (e.g. Claude API error mid-stream)
+      if (!accumulatedRef.current.trim()) {
+        setError("Generation returned no content. Check that the AI service is reachable and try again.");
+        setStep("wizard");
+        return;
+      }
+
       // Final content update
       if (editor) {
         editor.commands.setContent(markdownToHtml(accumulatedRef.current), { emitUpdate: false });


### PR DESCRIPTION
## Summary

- Server: adds try/catch around `streamText` and a custom `onError` callback for logging
- Client: guards against empty stream response — shows error instead of saving blank content

## Root cause

When the Claude API stream fails silently (network/SSL error), the stream ends with no text. The client was blindly saving the empty editor state, producing a document with only a title and no body.

## Test plan

- [ ] Generate a document normally — content streams and saves correctly
- [ ] If Claude API is unreachable, the generator shows "Generation returned no content. Check that the AI service is reachable and try again." and returns to the wizard step
- [ ] Server console shows the stream error if Claude fails

Closes #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)