### PR TITLE
Fix: set is_admin=true for admin@bricks.local in seed (#78)

### DIFF
--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -128,7 +128,7 @@ on conflict (provider, provider_id) do nothing;
 -- The handle_new_user trigger creates the profiles row on auth.users insert.
 -- We UPDATE to set display names and language preferences.
 -- ---------------------------------------------------------------------------
-update public.profiles set full_name = 'Alex Admin',      language = 'no' where id = '00000000-0000-0000-0000-000000000001';
+update public.profiles set full_name = 'Alex Admin',      language = 'no', is_admin = true  where id = '00000000-0000-0000-0000-000000000001';
 update public.profiles set full_name = 'Anna Architect',  language = 'no' where id = '00000000-0000-0000-0000-000000000002';
 update public.profiles set full_name = 'Erik Engineer',   language = 'en' where id = '00000000-0000-0000-0000-000000000003';
 update public.profiles set full_name = 'Carl Carpenter',  language = 'no' where id = '00000000-0000-0000-0000-000000000004';


### PR DESCRIPTION
## Summary

Adds `is_admin = true` to the `admin@bricks.local` profile in `seed.sql` so the knowledge management page is accessible after `supabase db reset`.

## Root cause

The `is_admin` column defaults to `false`. The seed never set it for the admin demo user, causing `/admin/knowledge` to redirect away.

## Test plan

- [ ] Run `supabase db reset`
- [ ] Log in as `admin@bricks.local`
- [ ] Navigate to `/en/app/admin/knowledge` — page loads correctly

Closes #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)