### PR TITLE
Fix PDF ingestion: webpack exclusion + OPENAI_API_KEY validation

### DIFF
--- a/app/api/rag/ingest/route.ts
+++ b/app/api/rag/ingest/route.ts
@@ -57,6 +57,13 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: "language must be 'no' or 'en'" }, { status: 400 });
   }
 
+  if (!process.env.OPENAI_API_KEY) {
+    return NextResponse.json(
+      { error: "OPENAI_API_KEY is not configured. Add it to .env.local to enable PDF ingestion." },
+      { status: 500 },
+    );
+  }
+
   const admin = createAdminClient();
   const startTime = Date.now();
 
@@ -178,12 +185,13 @@ export async function POST(request: Request) {
 
     return NextResponse.json({ sourceId, status: finalStatus, chunkCount: successCount, failedChunks: failCount });
   } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
     console.error("Ingestion error:", err);
     await admin
       .from("knowledge_sources")
       .update({ status: "failed", updated_at: new Date().toISOString() })
       .eq("id", sourceId);
     await admin.storage.from("documents").remove([storagePath]);
-    return NextResponse.json({ error: "Ingestion failed. Please try again." }, { status: 500 });
+    return NextResponse.json({ error: `Ingestion failed: ${message}` }, { status: 500 });
   }
 }

--- a/next.config.ts
+++ b/next.config.ts
@@ -4,6 +4,9 @@ import createNextIntlPlugin from "next-intl/plugin";
 const withNextIntl = createNextIntlPlugin("./i18n/request.ts");
 
 const nextConfig: NextConfig = {
+  // pdf-parse uses pdfjs-dist which spawns Node.js worker threads at runtime.
+  // Bundling it with webpack breaks worker file path resolution.
+  serverExternalPackages: ["pdf-parse"],
   experimental: {
     serverActions: {
       bodySizeLimit: "25mb",


### PR DESCRIPTION
## Summary

- Add `pdf-parse` to `serverExternalPackages` so pdfjs worker threads are not broken by Next.js webpack bundling — this was the primary cause of the `"Ingestion failed"` catch-all error
- Add early `OPENAI_API_KEY` check that returns a descriptive error instead of silently exhausting the embedding retry loop
- Surface the actual exception message from the outer catch so future failures are immediately diagnosable

## Test plan

- [ ] Restart dev server (`npm run dev`)
- [ ] Navigate to `/en/app/admin/knowledge`
- [ ] Upload TEK17 PDF — if `OPENAI_API_KEY` is missing, expect: `"OPENAI_API_KEY is not configured. Add it to .env.local to enable PDF ingestion."`
- [ ] Add a valid `OPENAI_API_KEY` to `.env.local`, restart, re-upload — expect success

Closes #86

🤖 Generated with [Claude Code](https://claude.com/claude-code)