### PR TITLE
Fix ingestion status display: correct colors and surface embed errors

### DIFF
--- a/app/api/rag/ingest/route.ts
+++ b/app/api/rag/ingest/route.ts
@@ -128,6 +128,7 @@ export async function POST(request: Request) {
     // ── Embed and store in batches ────────────────────────────────────────
     let successCount = 0;
     let failCount = 0;
+    let lastEmbedError: string | null = null;
 
     for (let batchStart = 0; batchStart < chunks.length; batchStart += EMBED_BATCH_SIZE) {
       const batch = chunks.slice(batchStart, batchStart + EMBED_BATCH_SIZE);
@@ -136,9 +137,12 @@ export async function POST(request: Request) {
       for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
         try {
           embeddings = await embedBatch(batch);
+          lastEmbedError = null;
           break;
         } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err);
           console.error("Embedding batch attempt failed:", { batchStart, attempt }, err);
+          lastEmbedError = msg;
           if (attempt === MAX_RETRIES) {
             failCount += batch.length;
           }
@@ -183,7 +187,13 @@ export async function POST(request: Request) {
     const duration = Date.now() - startTime;
     console.log("Ingestion complete:", { sourceId, successCount, failCount, status: finalStatus, durationMs: duration });
 
-    return NextResponse.json({ sourceId, status: finalStatus, chunkCount: successCount, failedChunks: failCount });
+    return NextResponse.json({
+      sourceId,
+      status: finalStatus,
+      chunkCount: successCount,
+      failedChunks: failCount,
+      ...(lastEmbedError ? { embedError: lastEmbedError } : {}),
+    });
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     console.error("Ingestion error:", err);

--- a/components/knowledge-source-manager.tsx
+++ b/components/knowledge-source-manager.tsx
@@ -32,6 +32,7 @@ type IngestResult = {
   chunkCount?: number;
   failedChunks?: number;
   error?: string;
+  embedError?: string;
 };
 
 function formatDate(iso: string) {
@@ -186,26 +187,36 @@ export function KnowledgeSourceManager({ initialSources }: { initialSources: Sou
             </div>
           </div>
 
-          {uploadResult && (
-            <div
-              className={cn(
-                "flex items-start gap-2 rounded-md px-3 py-2 text-sm",
-                uploadResult.error
-                  ? "bg-destructive/10 text-destructive"
-                  : "bg-green-50 dark:bg-green-900/20 text-green-700 dark:text-green-400",
-              )}
-            >
-              {uploadResult.error ? (
-                <XCircle className="h-4 w-4 mt-0.5 shrink-0" />
-              ) : (
-                <CheckCircle className="h-4 w-4 mt-0.5 shrink-0" />
-              )}
-              <span>
-                {uploadResult.error ??
-                  `Ingested ${uploadResult.chunkCount} chunks (status: ${uploadResult.status}${uploadResult.failedChunks ? `, ${uploadResult.failedChunks} failed` : ""})`}
-              </span>
-            </div>
-          )}
+          {uploadResult && (() => {
+            const isError = !!uploadResult.error || uploadResult.status === "failed";
+            const isPartial = uploadResult.status === "partial";
+            const isSuccess = uploadResult.status === "ready";
+            return (
+              <div
+                className={cn(
+                  "flex items-start gap-2 rounded-md px-3 py-2 text-sm",
+                  isError
+                    ? "bg-destructive/10 text-destructive"
+                    : isPartial
+                      ? "bg-yellow-50 dark:bg-yellow-900/20 text-yellow-700 dark:text-yellow-400"
+                      : "bg-green-50 dark:bg-green-900/20 text-green-700 dark:text-green-400",
+                )}
+              >
+                {isError || isPartial ? (
+                  <XCircle className="h-4 w-4 mt-0.5 shrink-0" />
+                ) : (
+                  <CheckCircle className="h-4 w-4 mt-0.5 shrink-0" />
+                )}
+                <span>
+                  {uploadResult.error
+                    ? uploadResult.error
+                    : isSuccess
+                      ? `Ingested ${uploadResult.chunkCount} chunks successfully`
+                      : `Ingested ${uploadResult.chunkCount ?? 0} chunks (${uploadResult.failedChunks} failed)${uploadResult.embedError ? ` — ${uploadResult.embedError}` : ""}`}
+                </span>
+              </div>
+            );
+          })()}
 
           <Button type="submit" size="sm" disabled={isUploading || !selectedFile || !title.trim()}>
             {isUploading ? (


### PR DESCRIPTION
## Summary

- **Root cause**: Capture the actual embedding error from the retry loop and include it as `embedError` in the API response — admins now see *why* embeddings failed (e.g. network blocked, invalid key, rate limit)
- **UI fix**: Result banner now shows red for `failed`/`error`, yellow for `partial`, green only for `status === 'ready'` — previously all outcomes showed green with a checkmark
- Inline `embedError` message displayed in the banner so the cause is immediately visible without checking logs

## Test plan

- [ ] Upload a PDF with a missing/invalid OpenAI key → red banner with error reason
- [ ] Upload a valid PDF with a working OpenAI key → green "Ingested N chunks successfully"
- [ ] Simulate partial failure → yellow banner

Closes #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)