### PR TITLE
Switch embeddings from OpenAI to Voyage AI (voyage-3, 1024 dims)

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -17,11 +17,10 @@ SUPABASE_SERVICE_ROLE_KEY=<paste service_role key from `supabase start` output>
 # Get from: https://console.anthropic.com
 ANTHROPIC_API_KEY=<your-anthropic-api-key>
 
-# ─── OpenAI ───────────────────────────────────────────────────────────────────
-# Required for semantic search embeddings (text-embedding-3-small).
-# If not set, keyword search still works; semantic search is skipped silently.
-# Get from: https://platform.openai.com
-OPENAI_API_KEY=<your-openai-api-key>
+# ─── Voyage AI ────────────────────────────────────────────────────────────────
+# Required for PDF ingestion and semantic search embeddings (voyage-3, 1024 dims).
+# Free tier: 50M tokens/month. Get your key at: https://dash.voyageai.com
+VOYAGE_API_KEY=<your-voyage-api-key>
 
 # ─── Email (Resend) ───────────────────────────────────────────────────────────
 # Optional for local dev — email sending is skipped silently if not set.

--- a/app/api/rag/ingest/route.ts
+++ b/app/api/rag/ingest/route.ts
@@ -57,9 +57,9 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: "language must be 'no' or 'en'" }, { status: 400 });
   }
 
-  if (!process.env.OPENAI_API_KEY) {
+  if (!process.env.VOYAGE_API_KEY) {
     return NextResponse.json(
-      { error: "OPENAI_API_KEY is not configured. Add it to .env.local to enable PDF ingestion." },
+      { error: "VOYAGE_API_KEY is not configured. Add it to .env.local to enable PDF ingestion." },
       { status: 500 },
     );
   }

--- a/lib/ai/embeddings.ts
+++ b/lib/ai/embeddings.ts
@@ -2,19 +2,22 @@ import "server-only";
 import { embed, embedMany } from "ai";
 import { createOpenAI } from "@ai-sdk/openai";
 
-export const EMBEDDING_MODEL = "text-embedding-3-small" as const;
-export const EMBEDDING_DIMENSIONS = 1536 as const;
+export const EMBEDDING_MODEL = "voyage-3" as const;
+export const EMBEDDING_DIMENSIONS = 1024 as const;
 
-function getOpenAIProvider() {
-  const apiKey = process.env.OPENAI_API_KEY;
+function getVoyageProvider() {
+  const apiKey = process.env.VOYAGE_API_KEY;
   if (!apiKey) {
-    throw new Error("OPENAI_API_KEY environment variable is not set");
+    throw new Error("VOYAGE_API_KEY environment variable is not set");
   }
-  return createOpenAI({ apiKey });
+  return createOpenAI({
+    apiKey,
+    baseURL: "https://api.voyageai.com/v1",
+  });
 }
 
 function getEmbeddingModel() {
-  return getOpenAIProvider().embedding(EMBEDDING_MODEL);
+  return getVoyageProvider().embedding(EMBEDDING_MODEL);
 }
 
 /** Generate a single embedding vector for a text string. */

--- a/supabase/migrations/20260311000000_voyage_ai_embeddings.sql
+++ b/supabase/migrations/20260311000000_voyage_ai_embeddings.sql
@@ -1,0 +1,63 @@
+-- =============================================================================
+-- Switch embeddings from OpenAI text-embedding-3-small (1536 dims)
+-- to Voyage AI voyage-3 (1024 dims)
+-- Migration: 20260311000000_voyage_ai_embeddings
+-- =============================================================================
+
+-- Drop HNSW index (depends on the vector column type)
+drop index if exists public.embeddings_embedding_idx;
+
+-- Clear any existing rows — dimensions are incompatible; all sources must be
+-- re-ingested anyway since the embedding model has changed.
+truncate table public.embeddings restart identity cascade;
+
+-- Change vector dimension from 1536 → 1024
+alter table public.embeddings
+  alter column embedding type vector(1024);
+
+-- Update default model label
+alter table public.embeddings
+  alter column embedding_model set default 'voyage-3';
+
+-- Recreate HNSW index for the new dimension
+create index on public.embeddings using hnsw (embedding vector_cosine_ops);
+
+-- Update match_documents RPC to use vector(1024)
+create or replace function public.match_documents(
+  query_embedding  vector(1024),
+  match_count      int     default 5,
+  filter_language  text    default null
+)
+returns table (
+  id                     uuid,
+  content                text,
+  language               text,
+  similarity             float,
+  knowledge_source_id    uuid,
+  knowledge_source_title text
+)
+language sql
+stable
+as $$
+  select
+    e.id,
+    e.content,
+    e.language::text,
+    1 - (e.embedding <=> query_embedding) as similarity,
+    e.knowledge_source_id,
+    ks.title as knowledge_source_title
+  from public.embeddings e
+  join public.knowledge_sources ks on ks.id = e.knowledge_source_id
+  where
+    (filter_language is null or e.language::text = filter_language)
+    and e.embedding is not null
+    and ks.status = 'ready'
+  order by e.embedding <=> query_embedding
+  limit match_count;
+$$;
+
+-- Reset knowledge_sources that were left in failed/partial state so they
+-- can be re-ingested cleanly with the new model.
+update public.knowledge_sources
+  set status = 'pending', chunk_count = 0, updated_at = now()
+  where status in ('failed', 'partial');


### PR DESCRIPTION
## Summary

- Replace OpenAI embeddings (`text-embedding-3-small`, 1536 dims) with Voyage AI (`voyage-3`, 1024 dims) — free tier gives 50M tokens/month
- Voyage AI exposes an OpenAI-compatible API so the switch is minimal: just `baseURL` + model name change in `lib/ai/embeddings.ts`
- Migration truncates the embeddings table (no successful ingestions existed), changes the column from `vector(1536)` → `vector(1024)`, recreates the HNSW index, and updates the `match_documents` RPC signature
- Resets any `failed`/`partial` knowledge sources to `pending` so they can be re-ingested

## Setup

1. Get a free API key at https://dash.voyageai.com
2. Add `VOYAGE_API_KEY=<key>` to `.env.local`
3. Run `supabase db reset` (already applied locally)
4. Restart dev server

Closes #94

🤖 Generated with [Claude Code](https://claude.com/claude-code)