### PR TITLE
Fix Voyage AI 400: call REST API directly instead of OpenAI compat layer

### DIFF
--- a/lib/ai/embeddings.ts
+++ b/lib/ai/embeddings.ts
@@ -1,39 +1,47 @@
 import "server-only";
-import { embed, embedMany } from "ai";
-import { createOpenAI } from "@ai-sdk/openai";
 
 export const EMBEDDING_MODEL = "voyage-3" as const;
 export const EMBEDDING_DIMENSIONS = 1024 as const;
 
-function getVoyageProvider() {
+type VoyageEmbeddingResponse = {
+  object: string;
+  data: Array<{ object: string; embedding: number[]; index: number }>;
+  model: string;
+  usage: { total_tokens: number };
+};
+
+function getApiKey(): string {
   const apiKey = process.env.VOYAGE_API_KEY;
-  if (!apiKey) {
-    throw new Error("VOYAGE_API_KEY environment variable is not set");
-  }
-  return createOpenAI({
-    apiKey,
-    baseURL: "https://api.voyageai.com/v1",
-  });
+  if (!apiKey) throw new Error("VOYAGE_API_KEY environment variable is not set");
+  return apiKey;
 }
 
-function getEmbeddingModel() {
-  return getVoyageProvider().embedding(EMBEDDING_MODEL);
+async function voyageEmbed(texts: string[]): Promise<number[][]> {
+  const res = await fetch("https://api.voyageai.com/v1/embeddings", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${getApiKey()}`,
+    },
+    body: JSON.stringify({ input: texts, model: EMBEDDING_MODEL, input_type: "document" }),
+  });
+
+  if (!res.ok) {
+    const body = await res.text();
+    throw new Error(`Voyage AI error ${res.status}: ${body}`);
+  }
+
+  const data = (await res.json()) as VoyageEmbeddingResponse;
+  return data.data.sort((a, b) => a.index - b.index).map((d) => d.embedding);
 }
 
 /** Generate a single embedding vector for a text string. */
 export async function embedText(text: string): Promise<number[]> {
-  const { embedding } = await embed({
-    model: getEmbeddingModel(),
-    value: text,
-  });
+  const [embedding] = await voyageEmbed([text]);
   return embedding;
 }
 
 /** Generate embeddings for multiple texts in a single API call. */
 export async function embedBatch(texts: string[]): Promise<number[][]> {
-  const { embeddings } = await embedMany({
-    model: getEmbeddingModel(),
-    values: texts,
-  });
-  return embeddings;
+  return voyageEmbed(texts);
 }


### PR DESCRIPTION
## Summary

Replaces the `@ai-sdk/openai` + `embedMany` approach with a plain `fetch` call directly to `https://api.voyageai.com/v1/embeddings`. The SDK was injecting OpenAI-specific fields Voyage AI rejects, causing 400 Bad Request on every batch.

The new implementation sends exactly what Voyage AI expects: `{ input, model, input_type: "document" }` and maps the response back to the same `number[][]` shape as before.

Closes #96

🤖 Generated with [Claude Code](https://claude.com/claude-code)