### PR TITLE
Upgrade dompurify to 3.3.3 to fix CVE-2026-0540 (#100)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "ai": "^6.0.111",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
-        "dompurify": "^3.3.1",
+        "dompurify": "^3.3.3",
         "lucide-react": "^0.577.0",
         "next": "16.1.6",
         "next-intl": "^4.8.3",
@@ -7295,9 +7295,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.1.tgz",
-      "integrity": "sha512-qkdCKzLNtrgPFP1Vo+98FRzJnBRGe4ffyCea9IwHB1fyxPOeNTHpLKYGd4Uk9xvNoH0ZoOjwZxNptyMwqrId1Q==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.3.tgz",
+      "integrity": "sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "ai": "^6.0.111",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
-    "dompurify": "^3.3.1",
+    "dompurify": "^3.3.3",
     "lucide-react": "^0.577.0",
     "next": "16.1.6",
     "next-intl": "^4.8.3",


### PR DESCRIPTION
## Summary

- Upgrades `dompurify` from 3.3.1 → 3.3.3 to patch CVE-2026-0540 (XSS vulnerability)
- No API changes; drop-in upgrade

## Test plan

- [ ] TypeScript compiles cleanly
- [ ] SCA / Dependabot alert #1 resolves
- [ ] Semgrep CI passes

Closes #100

🤖 Generated with [Claude Code](https://claude.com/claude-code)