### PR TITLE
Fix useSearchParams() Suspense boundary on legacy sign-in and join pages (#106)

### DIFF
--- a/app/(auth)/sign-in/page.tsx
+++ b/app/(auth)/sign-in/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { Suspense } from "react";
 import { useActionState } from "react";
 import Link from "next/link";
 import { useSearchParams } from "next/navigation";
@@ -18,7 +19,7 @@ import {
 
 const initialState: AuthState = {};
 
-export default function SignInPage() {
+function SignInForm() {
   const [state, formAction, pending] = useActionState(signIn, initialState);
   const searchParams = useSearchParams();
   const redirectTo = searchParams.get("redirectTo");
@@ -85,5 +86,13 @@ export default function SignInPage() {
         </CardFooter>
       </form>
     </Card>
+  );
+}
+
+export default function SignInPage() {
+  return (
+    <Suspense>
+      <SignInForm />
+    </Suspense>
   );
 }

--- a/app/app/projects/join/page.tsx
+++ b/app/app/projects/join/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { Suspense, useEffect, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { joinProject } from "@/lib/actions/projects";
 import { Button } from "@/components/ui/button";
@@ -14,7 +14,7 @@ import {
 } from "@/components/ui/card";
 import { Logo } from "@/components/logo";
 
-export default function JoinProjectPage() {
+function JoinProjectForm() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const token = searchParams.get("token");
@@ -100,5 +100,13 @@ export default function JoinProjectPage() {
         </Card>
       </div>
     </div>
+  );
+}
+
+export default function JoinProjectPage() {
+  return (
+    <Suspense>
+      <JoinProjectForm />
+    </Suspense>
   );
 }


### PR DESCRIPTION
## Summary

- Adds `<Suspense>` wrapper to `app/(auth)/sign-in/page.tsx` (legacy non-locale route)
- Adds `<Suspense>` wrapper to `app/app/projects/join/page.tsx` (legacy non-locale route)
- Fixes Vercel build failure: `useSearchParams() should be wrapped in a suspense boundary at page "/sign-in"`

The `[locale]` versions of these pages were already fixed; the pre-i18n copies were missed.

## Test plan

- [ ] TypeScript compiles cleanly
- [ ] Semgrep and SCA CI pass
- [ ] Vercel build succeeds

Closes #106

🤖 Generated with [Claude Code](https://claude.com/claude-code)