### PR TITLE
Add maxDuration = 60 to all AI routes (#112)

### DIFF
--- a/app/api/ai/chat/route.ts
+++ b/app/api/ai/chat/route.ts
@@ -7,6 +7,9 @@ import { getClaudeModel, DEFAULT_MODEL } from "@/lib/ai/claude";
 // NOTE: This is per-instance. In a multi-instance / edge deployment, replace
 // with a distributed store (Upstash Redis, Vercel KV, or Supabase RPC).
 // ---------------------------------------------------------------------------
+// Allow up to 60 s for auth + Claude streaming response.
+export const maxDuration = 60;
+
 const rateMap = new Map<string, { count: number; resetAt: number }>();
 
 function checkRateLimit(userId: string, maxPerMinute = 10): boolean {

--- a/app/api/ai/generate/route.ts
+++ b/app/api/ai/generate/route.ts
@@ -4,6 +4,9 @@ import { getUserProjectRole } from "@/lib/auth/rbac";
 import { getClaudeModel, DEFAULT_MODEL } from "@/lib/ai/claude";
 import { matchDocuments } from "@/lib/ai/rag";
 
+// Allow up to 60 s for auth + RAG retrieval + Claude streaming response.
+export const maxDuration = 60;
+
 const MAX_INPUT_LENGTH = 1000;
 
 function sanitize(input: string): string {

--- a/app/api/ai/suggestions/route.ts
+++ b/app/api/ai/suggestions/route.ts
@@ -47,6 +47,9 @@ function tiptapToText(node: Record<string, unknown>): string {
   return blockTypes.has(node.type as string) ? text + "\n" : text;
 }
 
+// Allow up to 60 s for auth + RAG retrieval + Claude streaming response.
+export const maxDuration = 60;
+
 // ---------------------------------------------------------------------------
 // POST /api/ai/suggestions
 // Body: { versionId: string, projectId: string }


### PR DESCRIPTION
## Summary

Adds `export const maxDuration = 60` to `suggestions`, `generate`, and `chat` routes — all were missing it, causing Vercel to terminate them at the default ~10s timeout before Claude could respond.

Closes #112

🤖 Generated with [Claude Code](https://claude.com/claude-code)