### PR TITLE
feat: email notifications for document events (#125)

### DIFF
--- a/lib/actions/comments.ts
+++ b/lib/actions/comments.ts
@@ -5,6 +5,7 @@ import { createClient } from "@/lib/supabase/server";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { getUserProjectRole } from "@/lib/auth/rbac";
 import { notify, notifyMany } from "@/lib/notifications/notify";
+import { sendCommentEmail, sendMentionEmail } from "@/lib/email/resend";
 
 /** Strip HTML tags and trim whitespace — comments are stored as plain text. */
 function sanitizeBody(input: string): string {
@@ -51,10 +52,11 @@ export async function postComment(
   // Fetch author name + doc owner once for all notifications below
   const [authorResult, docResult] = await Promise.all([
     admin.from("profiles").select("full_name").eq("id", user.id).single(),
-    admin.from("documents").select("created_by").eq("id", docId).single(),
+    admin.from("documents").select("created_by, title").eq("id", docId).single(),
   ]);
   const authorName = authorResult.data?.full_name ?? "Someone";
   const docOwnerId = docResult.data?.created_by ?? null;
+  const docTitle = docResult.data?.title ?? "a document";
 
   // ── @mention detection ──────────────────────────────────────────────────
   // Match @Word patterns (single token) against project members' first names.
@@ -88,6 +90,29 @@ export async function postComment(
           link: `/app/projects/${projectId}/documents/${docId}`,
         })),
       );
+
+      // Fire mention emails
+      const mentionEmailLookups = await Promise.all(
+        mentionedIds.map(async (userId) => {
+          const { data } = await admin.auth.admin.getUserById(userId);
+          return data.user?.email ?? null;
+        }),
+      );
+      void Promise.all(
+        mentionEmailLookups
+          .filter((email): email is string => email !== null)
+          .map((email) =>
+            sendMentionEmail({
+              to: email,
+              authorName,
+              docTitle,
+              commentBody: clean.slice(0, 200),
+              docLink: `/app/projects/${projectId}/documents/${docId}`,
+            }).catch((err) => {
+              console.error("Mention email send failed:", err);
+            }),
+          ),
+      );
     }
   }
 
@@ -100,6 +125,21 @@ export async function postComment(
       body: `${authorName}: ${clean.slice(0, 100)}`,
       link: `/app/projects/${projectId}/documents/${docId}`,
     });
+
+    // Fire comment email to doc owner
+    const { data: ownerUser } = await admin.auth.admin.getUserById(docOwnerId);
+    const ownerEmail = ownerUser.user?.email;
+    if (ownerEmail) {
+      void sendCommentEmail({
+        to: ownerEmail,
+        authorName,
+        docTitle,
+        commentBody: clean.slice(0, 200),
+        docLink: `/app/projects/${projectId}/documents/${docId}`,
+      }).catch((err) => {
+        console.error("Comment email send failed:", err);
+      });
+    }
   }
 
   revalidatePath(`/app/projects/${projectId}/documents/${docId}`);

--- a/lib/actions/workflow.ts
+++ b/lib/actions/workflow.ts
@@ -12,6 +12,7 @@ import type { SupabaseClient } from "@supabase/supabase-js";
 import type { Database } from "@/types/database";
 import { fireOutboundWebhooks } from "@/lib/webhooks/outbound";
 import { notifyMany } from "@/lib/notifications/notify";
+import { sendDocumentStatusEmail } from "@/lib/email/resend";
 
 const STATUS_LABELS: Record<DocumentStatus, string> = {
   draft: "Draft",
@@ -179,6 +180,29 @@ async function sendWorkflowNotifications({
           link,
         })),
       );
+
+      // Fire emails to all reviewers
+      const emailLookups = await Promise.all(
+        recipientIds.map(async (userId: string) => {
+          const { data } = await admin.auth.admin.getUserById(userId);
+          return data.user?.email ?? null;
+        }),
+      );
+      void Promise.all(
+        emailLookups
+          .filter((email): email is string => email !== null)
+          .map((email) =>
+            sendDocumentStatusEmail({
+              to: email,
+              actorName,
+              docTitle,
+              newStatus: "in_review",
+              docLink: link,
+            }).catch((err) => {
+              console.error("Status email send failed:", err);
+            }),
+          ),
+      );
     }
     return;
   }
@@ -207,5 +231,21 @@ async function sendWorkflowNotifications({
         link,
       },
     ]);
+
+    // Fire email to document creator
+    const { data: ownerUser } = await admin.auth.admin.getUserById(documentCreatedBy);
+    const ownerEmail = ownerUser.user?.email;
+    if (ownerEmail) {
+      void sendDocumentStatusEmail({
+        to: ownerEmail,
+        actorName,
+        docTitle,
+        newStatus,
+        docLink: link,
+        note,
+      }).catch((err) => {
+        console.error("Status email send failed:", err);
+      });
+    }
   }
 }

--- a/lib/ai/compliance.ts
+++ b/lib/ai/compliance.ts
@@ -6,6 +6,7 @@ import { createAdminClient } from "@/lib/supabase/admin";
 import { matchDocuments } from "@/lib/ai/rag";
 import { getClaudeModel, DEFAULT_MODEL } from "@/lib/ai/claude";
 import { notify } from "@/lib/notifications/notify";
+import { sendComplianceCompleteEmail } from "@/lib/email/resend";
 import type { Json } from "@/types/database";
 
 // ---------------------------------------------------------------------------
@@ -213,6 +214,7 @@ export async function runComplianceCheck(
     const docId = version.documents?.id;
     const projectId = version.documents?.project_id;
     if (docOwner && docId && projectId) {
+      const complianceLink = `/app/projects/${projectId}/documents/${docId}`;
       void notify({
         userId: docOwner,
         type: "compliance_complete",
@@ -221,10 +223,24 @@ export async function runComplianceCheck(
           object.issues.length === 0
             ? "No compliance issues found."
             : `${object.issues.length} issue${object.issues.length === 1 ? "" : "s"} found.`,
-        link: `/app/projects/${projectId}/documents/${docId}`,
+        link: complianceLink,
       }).catch((err) => {
         console.error("Compliance notification error:", err);
       });
+
+      // Fire compliance email to doc owner
+      const { data: ownerUser } = await admin.auth.admin.getUserById(docOwner);
+      const ownerEmail = ownerUser.user?.email;
+      if (ownerEmail) {
+        void sendComplianceCompleteEmail({
+          to: ownerEmail,
+          docTitle,
+          issueCount: object.issues.length,
+          docLink: complianceLink,
+        }).catch((err) => {
+          console.error("Compliance email send failed:", err);
+        });
+      }
     }
   } catch (err) {
     const duration = Date.now() - startTime;

--- a/lib/email/resend.ts
+++ b/lib/email/resend.ts
@@ -9,6 +9,38 @@ const FROM = "Bricks <noreply@bricks.build>";
 
 const IS_DEV = process.env.NODE_ENV === "development";
 
+// ---------------------------------------------------------------------------
+// Shared HTML template builder
+// ---------------------------------------------------------------------------
+function buildEmailHtml({
+  heading,
+  body,
+  ctaLabel,
+  ctaUrl,
+}: {
+  heading: string;
+  body: string;
+  ctaLabel: string;
+  ctaUrl: string;
+}): string {
+  return `
+    <div style="font-family:sans-serif;max-width:560px;margin:0 auto;color:#1a1a1a">
+      <div style="background:#0F2D5E;padding:24px 32px">
+        <span style="color:#fff;font-size:20px;font-weight:700;letter-spacing:-0.5px">Bricks</span>
+      </div>
+      <div style="padding:32px">
+        <h1 style="font-size:22px;font-weight:600;margin:0 0 12px">${heading}</h1>
+        <p style="color:#555;margin:0 0 24px">${body}</p>
+        <a href="${ctaUrl}"
+           style="display:inline-block;background:#C45C3A;color:#fff;text-decoration:none;
+                  padding:12px 24px;border-radius:6px;font-weight:600;font-size:15px">
+          ${ctaLabel}
+        </a>
+      </div>
+    </div>
+  `;
+}
+
 export async function sendProjectInviteEmail({
   to,
   inviterName,
@@ -72,5 +104,182 @@ export async function sendProjectInviteEmail({
   if (error) {
     console.error("Resend email error:", { to }, error.message);
     throw new Error(`Failed to send invite email: ${error.message}`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// sendDocumentStatusEmail
+// ---------------------------------------------------------------------------
+export async function sendDocumentStatusEmail({
+  to,
+  actorName,
+  docTitle,
+  newStatus,
+  docLink,
+  note,
+}: {
+  to: string;
+  actorName: string;
+  docTitle: string;
+  newStatus: "in_review" | "approved" | "changes_requested";
+  docLink: string;
+  note?: string;
+}) {
+  if (IS_DEV) {
+    console.log("[DEV] Status email skipped:", { to, newStatus, docTitle });
+    return;
+  }
+
+  const configs = {
+    in_review: {
+      subject: `"${docTitle}" is ready for review`,
+      heading: `${docTitle} — ready for review`,
+      body: `<strong>${actorName}</strong> submitted this document for review.`,
+      ctaLabel: "Review document",
+    },
+    approved: {
+      subject: `"${docTitle}" was approved`,
+      heading: `${docTitle} — approved`,
+      body: `<strong>${actorName}</strong> approved this document.`,
+      ctaLabel: "View document",
+    },
+    changes_requested: {
+      subject: `Changes requested on "${docTitle}"`,
+      heading: `${docTitle} — changes requested`,
+      body: `<strong>${actorName}</strong> requested changes.${note?.trim() ? `<br><br><em>${note.trim()}</em>` : ""}`,
+      ctaLabel: "View feedback",
+    },
+  } as const;
+
+  const cfg = configs[newStatus];
+  const { error } = await resend.emails.send({
+    from: FROM,
+    to,
+    subject: cfg.subject,
+    html: buildEmailHtml({
+      heading: cfg.heading,
+      body: cfg.body,
+      ctaLabel: cfg.ctaLabel,
+      ctaUrl: `${APP_URL}${docLink}`,
+    }),
+  });
+
+  if (error) {
+    console.error("Resend status email error:", { to, newStatus }, error.message);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// sendCommentEmail
+// ---------------------------------------------------------------------------
+export async function sendCommentEmail({
+  to,
+  authorName,
+  docTitle,
+  commentBody,
+  docLink,
+}: {
+  to: string;
+  authorName: string;
+  docTitle: string;
+  commentBody: string;
+  docLink: string;
+}) {
+  if (IS_DEV) {
+    console.log("[DEV] Comment email skipped:", { to, docTitle });
+    return;
+  }
+
+  const { error } = await resend.emails.send({
+    from: FROM,
+    to,
+    subject: `New comment on "${docTitle}"`,
+    html: buildEmailHtml({
+      heading: `New comment on ${docTitle}`,
+      body: `<strong>${authorName}</strong> commented:<br><br><em>${commentBody}</em>`,
+      ctaLabel: "View comment",
+      ctaUrl: `${APP_URL}${docLink}`,
+    }),
+  });
+
+  if (error) {
+    console.error("Resend comment email error:", { to }, error.message);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// sendMentionEmail
+// ---------------------------------------------------------------------------
+export async function sendMentionEmail({
+  to,
+  authorName,
+  docTitle,
+  commentBody,
+  docLink,
+}: {
+  to: string;
+  authorName: string;
+  docTitle: string;
+  commentBody: string;
+  docLink: string;
+}) {
+  if (IS_DEV) {
+    console.log("[DEV] Mention email skipped:", { to, docTitle });
+    return;
+  }
+
+  const { error } = await resend.emails.send({
+    from: FROM,
+    to,
+    subject: `${authorName} mentioned you in "${docTitle}"`,
+    html: buildEmailHtml({
+      heading: `You were mentioned in ${docTitle}`,
+      body: `<strong>${authorName}</strong> mentioned you in a comment:<br><br><em>${commentBody}</em>`,
+      ctaLabel: "View comment",
+      ctaUrl: `${APP_URL}${docLink}`,
+    }),
+  });
+
+  if (error) {
+    console.error("Resend mention email error:", { to }, error.message);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// sendComplianceCompleteEmail
+// ---------------------------------------------------------------------------
+export async function sendComplianceCompleteEmail({
+  to,
+  docTitle,
+  issueCount,
+  docLink,
+}: {
+  to: string;
+  docTitle: string;
+  issueCount: number;
+  docLink: string;
+}) {
+  if (IS_DEV) {
+    console.log("[DEV] Compliance email skipped:", { to, docTitle, issueCount });
+    return;
+  }
+
+  const hasIssues = issueCount > 0;
+  const { error } = await resend.emails.send({
+    from: FROM,
+    to,
+    subject: `Compliance check complete for "${docTitle}"`,
+    html: buildEmailHtml({
+      heading: "Compliance check complete",
+      body: hasIssues
+        ? `The compliance check for <strong>${docTitle}</strong> found <strong>${issueCount} issue${issueCount === 1 ? "" : "s"}</strong> that may require attention.`
+        : `The compliance check for <strong>${docTitle}</strong> found no issues. The document appears fully compliant.`,
+      ctaLabel: "View results",
+      ctaUrl: `${APP_URL}${docLink}`,
+    }),
+  });
+
+  if (error) {
+    console.error("Resend compliance email error:", { to }, error.message);
   }
 }


### PR DESCRIPTION
## Summary
- Adds transactional email notifications via Resend for all major document events
- Document submitted for review → emails all project reviewers (civil engineers + admins)
- Document approved or changes requested → emails the document author
- New comment posted → emails the document owner
- @mention in a comment → emails mentioned users
- Compliance check completes → emails the document owner

## Implementation
- Added `buildEmailHtml` shared template builder to `lib/email/resend.ts` (navy header, orange CTA — matches invite email brand)
- Added 4 new email functions: `sendDocumentStatusEmail`, `sendCommentEmail`, `sendMentionEmail`, `sendComplianceCompleteEmail`
- Hooked into existing trigger points: `lib/actions/workflow.ts`, `lib/actions/comments.ts`, `lib/ai/compliance.ts`
- Emails fire alongside in-app notifications (fire-and-forget, errors logged but not surfaced)
- `IS_DEV` guard skips sends in local development (logs to console instead)
- Recipient emails looked up via `admin.auth.admin.getUserById`

## Test plan
- [ ] Submit a document for review — reviewer(s) should receive email
- [ ] Approve a document — author should receive email
- [ ] Request changes on a document — author should receive email with note
- [ ] Post a comment on a document — document owner should receive email
- [ ] @mention a teammate in a comment — mentioned user should receive email
- [ ] Run compliance check — document owner should receive email with issue count
- [ ] Verify no emails sent in local development (check server console for `[DEV] ... email skipped`)

Closes #125

🤖 Generated with [Claude Code](https://claude.com/claude-code)