### PR TITLE
fix: add doc_embeddings to database types and remove 12 unsafe as any casts

### DIFF
--- a/app/api/integrations/[id]/logs/route.ts
+++ b/app/api/integrations/[id]/logs/route.ts
@@ -23,7 +23,7 @@ export async function GET(
   if (!role) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
 
   const admin = createAdminClient();
-  const { data, error } = await (admin as any)
+  const { data, error } = await admin
     .from("integrations_log")
     .select(
       "id, direction, event_type, status, http_status_code, destination_url, attempt, error, created_at",

--- a/app/api/integrations/[id]/route.ts
+++ b/app/api/integrations/[id]/route.ts
@@ -23,7 +23,7 @@ export async function DELETE(
   if (role !== "admin") return NextResponse.json({ error: "Forbidden" }, { status: 403 });
 
   const admin = createAdminClient();
-  const { error } = await (admin as any)
+  const { error } = await admin
     .from("integrations")
     .delete()
     .eq("id", id)

--- a/app/api/integrations/route.ts
+++ b/app/api/integrations/route.ts
@@ -19,7 +19,7 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
   if (!role) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
 
   const admin = createAdminClient();
-  const { data, error } = await (admin as any)
+  const { data, error } = await admin
     .from("integrations")
     .select("id, name, type, webhook_url, status, created_at")
     .eq("project_id", projectId)

--- a/app/api/webhooks/[integrationId]/route.ts
+++ b/app/api/webhooks/[integrationId]/route.ts
@@ -19,7 +19,7 @@ export async function POST(
 
   const admin = createAdminClient();
 
-  const { data: integration } = await (admin as any)
+  const { data: integration } = await admin
     .from("integrations")
     .select("id, project_id, webhook_secret_enc, status")
     .eq("id", integrationId)
@@ -83,7 +83,7 @@ async function logInbound(
     error: string | null;
   },
 ): Promise<void> {
-  const { error } = await (admin as any).from("integrations_log").insert({
+  const { error } = await admin.from("integrations_log").insert({
     integration_id: entry.integrationId,
     project_id: entry.projectId,
     direction: "inbound",

--- a/lib/actions/integrations.ts
+++ b/lib/actions/integrations.ts
@@ -37,7 +37,7 @@ export async function createIntegration(
   const encrypted = encryptSecret(secret);
   const admin = createAdminClient();
 
-  const { error } = await (admin as any).from("integrations").insert({
+  const { error } = await admin.from("integrations").insert({
     project_id: projectId,
     name: name.trim(),
     type: "webhook_outbound",
@@ -66,7 +66,7 @@ export async function deleteIntegration(
   if (role !== "admin") return { error: "Only project admins can manage integrations" };
 
   const admin = createAdminClient();
-  const { error } = await (admin as any)
+  const { error } = await admin
     .from("integrations")
     .delete()
     .eq("id", integrationId)
@@ -93,7 +93,7 @@ export async function toggleIntegrationStatus(
   if (role !== "admin") return { error: "Only project admins can manage integrations" };
 
   const admin = createAdminClient();
-  const { error } = await (admin as any)
+  const { error } = await admin
     .from("integrations")
     .update({ status, updated_at: new Date().toISOString() })
     .eq("id", integrationId)

--- a/lib/actions/notifications.ts
+++ b/lib/actions/notifications.ts
@@ -55,7 +55,7 @@ export async function updateEmailPrefs(
   );
 
   const admin = createAdminClient();
-  const { error } = await (admin as any)
+  const { error } = await admin
     .from("profiles")
     .update({ email_prefs: sanitised, updated_at: new Date().toISOString() })
     .eq("id", user.id);

--- a/lib/notifications/email.ts
+++ b/lib/notifications/email.ts
@@ -40,14 +40,18 @@ export async function sendNotificationEmail(payload: EmailPayload): Promise<void
   const admin = createAdminClient();
 
   // Fetch user email + preferences in one query
-  const { data: profile } = await (admin as any)
+  const { data: profile } = await admin
     .from("profiles")
     .select("email_prefs, auth_users:id(email)")
     .eq("id", payload.userId)
     .single();
 
-  // Check opt-out preference
-  const prefs: Record<string, boolean> = profile?.email_prefs ?? {};
+  // Check opt-out preference — email_prefs is Json in the schema so narrow at runtime
+  const rawPrefs = profile?.email_prefs;
+  const prefs: Record<string, boolean> =
+    rawPrefs !== null && typeof rawPrefs === "object" && !Array.isArray(rawPrefs)
+      ? (rawPrefs as Record<string, boolean>)
+      : {};
   if (prefs[payload.type] === false) return;
 
   // Get user email from auth.users via admin API

--- a/lib/search/embed-document.ts
+++ b/lib/search/embed-document.ts
@@ -22,7 +22,7 @@ export async function embedDocument(documentId: string, title: string, descripti
   }
 
   const admin = createAdminClient();
-  const { error } = await (admin as any)
+  const { error } = await admin
     .from("doc_embeddings")
     .upsert(
       { document_id: documentId, embedding: JSON.stringify(embedding), updated_at: new Date().toISOString() },

--- a/lib/webhooks/outbound.ts
+++ b/lib/webhooks/outbound.ts
@@ -135,7 +135,7 @@ async function logDelivery(
     error: string | null;
   },
 ): Promise<void> {
-  const { error } = await (admin as any)
+  const { error } = await admin
     .from("integrations_log")
     .insert({
       integration_id: entry.integrationId,

--- a/types/database.ts
+++ b/types/database.ts
@@ -459,6 +459,32 @@ export type Database = {
           },
         ]
       }
+      doc_embeddings: {
+        Row: {
+          document_id: string
+          embedding: string | null
+          updated_at: string
+        }
+        Insert: {
+          document_id: string
+          embedding?: string | null
+          updated_at?: string
+        }
+        Update: {
+          document_id?: string
+          embedding?: string | null
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "doc_embeddings_document_id_fkey"
+            columns: ["document_id"]
+            isOneToOne: true
+            referencedRelation: "documents"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       embeddings: {
         Row: {
           chunk_index: number


### PR DESCRIPTION
## Summary

Fixes #160

### Root cause
`types/database.ts` was missing the `doc_embeddings` table (defined in migration `20260304000600_search.sql`). Because that table was absent from the Database type, 12 files cast the Supabase admin client to `as any` to avoid TypeScript errors — bypassing all type safety on those queries.

### Changes
- **`types/database.ts`** — add `doc_embeddings` table definition (Row / Insert / Update / Relationships) matching the SQL schema
- **9 source files** — replace every `(admin as any).from(...)` with the correctly-typed `admin.from(...)`
- **`lib/notifications/email.ts`** — narrow the `email_prefs` column (typed as `Json`) to `Record<string, boolean>` with a runtime guard instead of a bare type assignment

### Verification
- `npm run typecheck` — ✅ 0 errors
- `npm run lint` — ✅ 0 warnings