### PR TITLE
fix: remove dead auth_users PostgREST join from email preferences query

### DIFF
--- a/lib/notifications/email.ts
+++ b/lib/notifications/email.ts
@@ -39,10 +39,10 @@ export async function sendNotificationEmail(payload: EmailPayload): Promise<void
 
   const admin = createAdminClient();
 
-  // Fetch user email + preferences in one query
+  // Fetch notification preferences for the opt-out check
   const { data: profile } = await admin
     .from("profiles")
-    .select("email_prefs, auth_users:id(email)")
+    .select("email_prefs")
     .eq("id", payload.userId)
     .single();
 


### PR DESCRIPTION
## Summary

Fixes #162

### Problem
`lib/notifications/email.ts` queries `profiles` with:
```ts
.select("email_prefs, auth_users:id(email)")
```

The `auth_users:id(email)` PostgREST join is dead — PostgREST only exposes the `public` schema by default and cannot reach `auth.users` via a relationship. This selector always returns `null` and is never read anywhere in the function: the actual user email is correctly retrieved via `admin.auth.admin.getUserById()` on the next line.

### Fix
Remove the dead selector — keep only `email_prefs`, which is the only column consumed by the opt-out check.

### Verification
- `npm run typecheck` — ✅ 0 errors
- `npm run lint` — ✅ 0 warnings