### PR TITLE
fix: use Next.js after() to keep auto-compliance check alive on Vercel

### DIFF
--- a/lib/actions/workflow.ts
+++ b/lib/actions/workflow.ts
@@ -1,6 +1,7 @@
 "use server";
 
 import { revalidatePath } from "next/cache";
+import { after } from "next/server";
 import { createClient } from "@/lib/supabase/server";
 import { createAdminClient } from "@/lib/supabase/admin";
 import {
@@ -103,9 +104,11 @@ export async function transitionDocumentStatus(
 
   // Auto-trigger compliance check when submitted for review
   if (newStatus === "in_review") {
-    void triggerAutoComplianceCheck(admin, docId, user.id).catch((err) => {
-      console.error("Auto-compliance trigger failed:", err);
-    });
+    after(() =>
+      triggerAutoComplianceCheck(admin, docId, user.id).catch((err) => {
+        console.error("Auto-compliance trigger failed:", err);
+      }),
+    );
   }
 
   // Non-blocking notifications


### PR DESCRIPTION
## Summary

Fixes #164

### Problem
`triggerAutoComplianceCheck` was called with `void` (fire-and-forget) inside a server action. `runComplianceCheck` can take up to 60 seconds — but Vercel terminates a serverless invocation the moment the server action sends its response, which can kill the compliance check mid-run.

### Fix
Wrap the call with `after()` from `next/server`:
```ts
after(() =>
  triggerAutoComplianceCheck(admin, docId, user.id).catch((err) => {
    console.error("Auto-compliance trigger failed:", err);
  }),
);
```
`after()` registers the callback as post-response work that the Vercel runtime guarantees to keep alive until the callback's Promise resolves.

### Verification
- `npm run typecheck` — ✅ 0 errors
- `npm run lint` — ✅ 0 warnings