### PR TITLE
fix: patch two SSRF bypass vectors in ssrf.ts

### DIFF
--- a/lib/webhooks/ssrf.ts
+++ b/lib/webhooks/ssrf.ts
@@ -22,19 +22,53 @@ function ipv4ToInt(ip: string): number {
 
 function isPrivateIpv4(ip: string): boolean {
   const n = ipv4ToInt(ip);
-  return PRIVATE_RANGES.some(([net, mask]) => (n & mask) === net);
+  // Use >>> 0 on both sides: JS bitwise & returns a signed 32-bit int, but
+  // net constants like 0xc0a80000 are stored as positive doubles — without
+  // the unsigned-right-shift the comparison fails for all IPs >= 128.0.0.0.
+  return PRIVATE_RANGES.some(([net, mask]) => ((n & mask) >>> 0) === (net >>> 0));
 }
 
 function isPrivateIpv6(ip: string): boolean {
   // Normalised lowercase check for common reserved IPv6
   const lower = ip.toLowerCase().replace(/^\[/, "").replace(/\]$/, "");
-  return (
+
+  if (
     lower === "::1" ||
     lower.startsWith("fc") ||
     lower.startsWith("fd") ||
     lower.startsWith("fe80:") ||
     lower === "::"
-  );
+  ) {
+    return true;
+  }
+
+  // IPv4-mapped IPv6 (::ffff:a.b.c.d or ::ffff:xxyy:zzww) — e.g. ::ffff:127.0.0.1
+  if (lower.startsWith("::ffff:")) {
+    const rest = lower.slice("::ffff:".length);
+
+    // Dotted-decimal form: ::ffff:127.0.0.1
+    if (/^\d{1,3}(\.\d{1,3}){3}$/.test(rest)) {
+      return isPrivateIpv4(rest);
+    }
+
+    // Hex-group form: ::ffff:7f00:1  (each group is 16 bits)
+    const parts = rest.split(":");
+    if (parts.length === 2) {
+      const high = parseInt(parts[0], 16);
+      const low = parseInt(parts[1], 16);
+      if (!isNaN(high) && !isNaN(low)) {
+        const synthetic = [
+          (high >> 8) & 0xff,
+          high & 0xff,
+          (low >> 8) & 0xff,
+          low & 0xff,
+        ].join(".");
+        return isPrivateIpv4(synthetic);
+      }
+    }
+  }
+
+  return false;
 }
 
 /**


### PR DESCRIPTION
## Summary

Fixes #166

Two separate SSRF bypass vulnerabilities found in `lib/webhooks/ssrf.ts`.

---

### Bug 1 — IPv4-mapped IPv6 addresses bypass SSRF check

A webhook URL like `http://[::ffff:127.0.0.1]/` or `http://[::ffff:7f00:1]/` was not caught by `isPrivateIpv6`. The fix adds detection for both address forms:

- **Dotted-decimal**: `::ffff:127.0.0.1` → extract IPv4 suffix → `isPrivateIpv4`
- **Hex-group**: `::ffff:7f00:1` → decode each 16-bit group → `isPrivateIpv4`

---

### Bug 2 — `isPrivateIpv4` silently fails for addresses ≥ 128.0.0.0

`192.168.x.x`, `172.16.x.x`, and `169.254.x.x` were all allowed through. Root cause: JavaScript's bitwise `&` returns a **signed 32-bit integer**, but the `net` constants (e.g. `0xc0a80000`) are positive 64-bit doubles. For any IP with the high bit set the comparison `(n & mask) === net` evaluates to `(-1062731776 === 3232235520)` → `false`.

Fix: apply `>>> 0` to both sides before comparing.

---

### Verified with inline smoke tests (all cases pass)
| Address | Expected | Result |
|---|---|---|
| `192.168.1.1` | blocked | ✅ |
| `172.16.0.1` | blocked | ✅ |
| `169.254.1.1` | blocked | ✅ |
| `::ffff:127.0.0.1` | blocked | ✅ |
| `::ffff:192.168.1.1` | blocked | ✅ |
| `::ffff:7f00:1` | blocked | ✅ |
| `::ffff:c0a8:101` | blocked | ✅ |
| `8.8.8.8` | allowed | ✅ |
| `::ffff:8.8.8.8` | allowed | ✅ |

### Verification
- `npm run typecheck` — ✅ 0 errors
- `npm run lint` — ✅ 0 warnings