### PR TITLE
fix: replace raw <img> with Next.js <Image> in document viewer

### DIFF
--- a/components/document-viewer-client.tsx
+++ b/components/document-viewer-client.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Image from "next/image";
 import { useState } from "react";
 import DOMPurify from "dompurify";
 import {
@@ -309,13 +310,21 @@ export function DocumentViewerClient({
               />
             ) : isImage && content?.type === "file" && content.url ? (
               <div className="flex items-start justify-center p-6 min-h-full">
-                {/* eslint-disable-next-line @next/next/no-img-element */}
-                <img
+                <Image
                   key={content.url}
                   src={content.url}
                   alt={document.title}
-                  style={{ transform: `scale(${zoom})`, transformOrigin: "top center" }}
-                  className="max-w-full transition-transform duration-150"
+                  width={0}
+                  height={0}
+                  sizes="100vw"
+                  style={{
+                    width: "auto",
+                    height: "auto",
+                    maxWidth: "100%",
+                    transform: `scale(${zoom})`,
+                    transformOrigin: "top center",
+                  }}
+                  className="transition-transform duration-150"
                 />
               </div>
             ) : (

--- a/next.config.ts
+++ b/next.config.ts
@@ -9,6 +9,23 @@ const nextConfig: NextConfig = {
       bodySizeLimit: "25mb",
     },
   },
+  images: {
+    remotePatterns: [
+      // Supabase Storage — production (*.supabase.co)
+      {
+        protocol: "https",
+        hostname: "*.supabase.co",
+        pathname: "/storage/v1/object/**",
+      },
+      // Supabase Storage — local dev (supabase start)
+      {
+        protocol: "http",
+        hostname: "127.0.0.1",
+        port: "54321",
+        pathname: "/storage/v1/object/**",
+      },
+    ],
+  },
 };
 
 export default withNextIntl(nextConfig);


### PR DESCRIPTION
## Summary

Fixes #168

### Problem
`components/document-viewer-client.tsx` used a raw `<img>` element with an `eslint-disable-next-line @next/next/no-img-element` suppression comment for image file previews. This bypasses Next.js's lazy loading, automatic WebP/AVIF conversion, and browser size hints.

### Changes

**`next.config.ts`** — add `images.remotePatterns`:
- `https://*.supabase.co/storage/v1/object/**` (production)
- `http://127.0.0.1:54321/storage/v1/object/**` (local dev)

**`components/document-viewer-client.tsx`**:
- Import `Image` from `next/image`
- Replace `<img>` with `<Image width={0} height={0} sizes="100vw">` using `style={{ width: 'auto', height: 'auto' }}` — the standard Next.js pattern to render images at their natural size while enabling optimisation
- Move the zoom transform into the `style` prop
- Remove the `eslint-disable-next-line` comment

### Verification
- `npm run typecheck` — ✅ 0 errors
- `npm run lint` — ✅ 0 warnings